### PR TITLE
Implement MSVC CPU feature detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Any entry that would change it would be a new algorithm, not a release.
 
 ## [Unreleased]
 
+### Changed
+- x86 CPU detection now uses a raw CPUID + `XGETBV` probe on every compiler
+  instead of `__builtin_cpu_supports`. MSVC previously had no detection at all
+  and reported no features, so MSVC builds ran scalar even on AVX2 hardware;
+  they now resolve the same backend as GCC and Clang. `tests/test_cpu_features.cpp`
+  checks the probe against `__builtin_cpu_supports` wherever that builtin
+  exists, so the path MSVC depends on is exercised on every Linux and macOS run.
+
 ## [2026.08.0] — 2026-08-21
 
 Initial scaffold. Phase 0 complete, Phase 1 substantially complete.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,7 +109,10 @@ Philox counters across SIMD lanes.
 - [x] `detail/dispatch.hpp` — resolves to the fastest kernel that is compiled in **and** implemented **and** CPU-supported
 - [x] `VPHILOX_BACKEND` env override for pinning a backend in tests and benchmarks
 - [ ] SIMD float conversion — `_mm256_or_si256` + `_mm256_sub_ps` and the AVX-512/NEON equivalents, keeping conversion inside vector registers
-- [ ] MSVC CPU detection (`__cpuidex` leaf 7 + `XGETBV` OS-state check) — currently stubbed to `false`
+- [x] MSVC CPU detection (`__cpuidex` leaf 7 + `XGETBV` OS-state check) — no longer stubbed to `false`.
+      The CPUID probe is now the single x86 path on every compiler, so Linux and macOS runs
+      exercise the same code MSVC depends on; `tests/test_cpu_features.cpp` checks it against
+      `__builtin_cpu_supports` wherever that builtin exists
 - [ ] **Close the buffer overhead gap** — measured at ~22% (954 MiB/s buffered vs 1.231 GiB/s bulk).
       Phase 3's zero-cost-abstraction claim does not hold yet; profile the per-call bounds check
 - [ ] Bulk generation API (`generate_n` / span-filling) so callers can bypass the buffer entirely

--- a/include/vphilox/detail/cpu_features.hpp
+++ b/include/vphilox/detail/cpu_features.hpp
@@ -5,14 +5,26 @@
 //
 // Runtime CPU probing. Kept separate from dispatch so it can be tested and
 // overridden (VPHILOX_BACKEND env var) without touching kernel selection.
+//
+// The x86 probe is raw CPUID plus XGETBV rather than __builtin_cpu_supports,
+// and it is the same code on every x86 compiler. MSVC has no equivalent
+// builtin, so a compiler-split implementation would leave the MSVC path
+// untested everywhere except Windows CI. Sharing one path means every Linux
+// and macOS run exercises the code MSVC depends on, and
+// tests/test_cpu_features.cpp checks it against __builtin_cpu_supports
+// wherever that builtin exists.
 
 #ifndef VPHILOX_DETAIL_CPU_FEATURES_HPP
 #define VPHILOX_DETAIL_CPU_FEATURES_HPP
 
 #include "vphilox/config.hpp"
 
-#if defined(VPHILOX_ARCH_X86) && defined(_MSC_VER)
+#if defined(VPHILOX_ARCH_X86)
+#if defined(_MSC_VER)
 #include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
 #endif
 
 namespace vphilox::detail {
@@ -23,26 +35,103 @@ struct cpu_features {
     bool neon   = false;
 };
 
+#if defined(VPHILOX_ARCH_X86)
+
+namespace x86 {
+
+/// CPUID leaf/subleaf bits this probe reads.
+inline constexpr u32 leaf1_ecx_osxsave  = 1u << 27;
+inline constexpr u32 leaf7_ebx_avx2     = 1u << 5;
+inline constexpr u32 leaf7_ebx_avx512f  = 1u << 16;
+inline constexpr u32 leaf7_ebx_avx512dq = 1u << 17;
+
+/// XCR0 bits. A CPU can report an instruction set the OS has not agreed to
+/// save on context switch; using it then corrupts the vector registers of
+/// whatever runs next. Checking XCR0 is what makes the CPUID answer usable.
+inline constexpr u64 xcr0_sse       = 1ull << 1;
+inline constexpr u64 xcr0_avx       = 1ull << 2;
+inline constexpr u64 xcr0_opmask    = 1ull << 5;
+inline constexpr u64 xcr0_zmm_hi256 = 1ull << 6;
+inline constexpr u64 xcr0_hi16_zmm  = 1ull << 7;
+
+inline constexpr u64 xcr0_ymm_state = xcr0_sse | xcr0_avx;
+inline constexpr u64 xcr0_zmm_state = xcr0_ymm_state | xcr0_opmask | xcr0_zmm_hi256 | xcr0_hi16_zmm;
+
+struct cpuid_regs {
+    u32 eax = 0;
+    u32 ebx = 0;
+    u32 ecx = 0;
+    u32 edx = 0;
+};
+
+inline cpuid_regs cpuid(u32 leaf, u32 subleaf) noexcept {
+    cpuid_regs r{};
+#if defined(_MSC_VER)
+    int regs[4] = {0, 0, 0, 0};
+    __cpuidex(regs, static_cast<int>(leaf), static_cast<int>(subleaf));
+    r.eax = static_cast<u32>(regs[0]);
+    r.ebx = static_cast<u32>(regs[1]);
+    r.ecx = static_cast<u32>(regs[2]);
+    r.edx = static_cast<u32>(regs[3]);
+#else
+    __cpuid_count(leaf, subleaf, r.eax, r.ebx, r.ecx, r.edx);
+#endif
+    return r;
+}
+
+/// Read XCR0. Only valid once OSXSAVE is known to be set -- XGETBV faults
+/// otherwise. Raw asm on GCC/Clang rather than the _xgetbv intrinsic, which
+/// would require putting -mxsave on the whole build.
+inline u64 xcr0() noexcept {
+#if defined(_MSC_VER)
+    return static_cast<u64>(_xgetbv(0));
+#else
+    u32 lo = 0;
+    u32 hi = 0;
+    __asm__ __volatile__("xgetbv" : "=a"(lo), "=d"(hi) : "c"(0));
+    return (static_cast<u64>(hi) << 32) | lo;
+#endif
+}
+
+inline cpu_features probe() noexcept {
+    cpu_features f{};
+
+    // Leaf 7 carries the AVX2 and AVX-512 bits; nothing to ask if the CPU
+    // does not implement it.
+    if (cpuid(0, 0).eax < 7) return f;
+
+    // Without OSXSAVE the OS has not enabled XSAVE at all, so no extended
+    // vector state is preserved and XGETBV must not be executed.
+    if ((cpuid(1, 0).ecx & leaf1_ecx_osxsave) == 0) return f;
+
+    const u64 xcr        = xcr0();
+    const bool ymm_saved = (xcr & xcr0_ymm_state) == xcr0_ymm_state;
+    const bool zmm_saved = (xcr & xcr0_zmm_state) == xcr0_zmm_state;
+
+    const u32 leaf7_ebx = cpuid(7, 0).ebx;
+
+    f.avx2 = ymm_saved && (leaf7_ebx & leaf7_ebx_avx2) != 0;
+    f.avx512 =
+        zmm_saved && (leaf7_ebx & leaf7_ebx_avx512f) != 0 && (leaf7_ebx & leaf7_ebx_avx512dq) != 0;
+    return f;
+}
+
+}  // namespace x86
+
+#endif  // VPHILOX_ARCH_X86
+
 /// Probe once; the result cannot change during the process lifetime.
 inline const cpu_features& detect_cpu() noexcept {
     static const cpu_features features = [] {
-        cpu_features f{};
 #if defined(VPHILOX_ARCH_X86)
-#if defined(__GNUC__) || defined(__clang__)
-        __builtin_cpu_init();
-        f.avx2   = __builtin_cpu_supports("avx2");
-        f.avx512 = __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512dq");
-#elif defined(_MSC_VER)
-        // TODO(phase-3): MSVC path -- __cpuidex leaf 7 (EBX bit 5 = AVX2,
-        // bit 16 = AVX512F, bit 17 = AVX512DQ) plus an XGETBV check that the
-        // OS actually saves the YMM/ZMM state.
-        f.avx2   = false;
-        f.avx512 = false;
-#endif
+        return x86::probe();
 #elif defined(VPHILOX_ARCH_ARM64)
+        cpu_features f{};
         f.neon = true;  // NEON is mandatory on aarch64
-#endif
         return f;
+#else
+        return cpu_features{};
+#endif
     }();
     return features;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(VPHILOX_TEST_SOURCES
     test_reference_vectors.cpp # Phase 1: known-answer tests vs Random123
     test_counter.cpp          # Phase 1: 128-bit counter arithmetic
     test_kernel_parity.cpp    # Phase 2: SIMD kernels == scalar, bit for bit
+    test_cpu_features.cpp     # Phase 3: CPUID/XGETBV probe, shared with MSVC
     test_float_cast.cpp       # Phase 3: mantissa injection range/uniformity
     test_engine.cpp           # Phase 3: C++20 concept, buffer, discard
 )

--- a/tests/test_cpu_features.cpp
+++ b/tests/test_cpu_features.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Parth Sinha
+
+// Phase 3 gate: the x86 CPUID probe must agree with the compiler's own view of
+// the machine.
+//
+// This exists because MSVC has no __builtin_cpu_supports, so the CPUID path is
+// the only detection MSVC has -- and Windows CI is the one place we cannot
+// easily debug it. Running the identical code on Linux and macOS and checking
+// it against __builtin_cpu_supports means a mistake in the leaf numbers, the
+// bit positions, or the XGETBV mask fails on a runner we can inspect, rather
+// than silently leaving Windows users on the scalar kernel.
+
+#include <gtest/gtest.h>
+
+#include "vphilox/detail/cpu_features.hpp"
+#include "vphilox/detail/dispatch.hpp"
+
+using namespace vphilox;
+
+TEST(CpuFeatures, ProbeIsCached) {
+    // detect_cpu() hands out a reference to one probe result; the CPU cannot
+    // gain features mid-process.
+    const detail::cpu_features& first  = detail::detect_cpu();
+    const detail::cpu_features& second = detail::detect_cpu();
+    EXPECT_EQ(&first, &second);
+}
+
+#if defined(VPHILOX_ARCH_X86)
+
+TEST(CpuFeatures, CpuidAgreesWithCompilerBuiltin) {
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_cpu_init();
+
+    const detail::cpu_features probed = detail::x86::probe();
+
+    // __builtin_cpu_supports covers the OS-state check too, so this compares
+    // the whole answer, not just the CPUID bits.
+    EXPECT_EQ(probed.avx2, __builtin_cpu_supports("avx2") != 0);
+    EXPECT_EQ(probed.avx512,
+              __builtin_cpu_supports("avx512f") != 0 && __builtin_cpu_supports("avx512dq") != 0);
+#else
+    GTEST_SKIP() << "no __builtin_cpu_supports to compare against (MSVC)";
+#endif
+}
+
+TEST(CpuFeatures, Avx512ImpliesXsaveEnabled) {
+    // AVX-512 requires the ZMM state bits, which are a superset of the YMM
+    // ones. A host reporting avx512 without a usable XSAVE configuration means
+    // the mask is wrong.
+    if (!detail::detect_cpu().avx512) GTEST_SKIP() << "no AVX-512 on this host";
+
+    const u64 xcr = detail::x86::xcr0();
+    EXPECT_EQ(xcr & detail::x86::xcr0_zmm_state, detail::x86::xcr0_zmm_state);
+    EXPECT_TRUE(detail::detect_cpu().avx2) << "AVX-512 host must also report AVX2 state";
+}
+
+TEST(CpuFeatures, NeonIsNeverReportedOnX86) {
+    EXPECT_FALSE(detail::detect_cpu().neon);
+}
+
+#elif defined(VPHILOX_ARCH_ARM64)
+
+TEST(CpuFeatures, NeonIsAlwaysPresentOnAarch64) {
+    EXPECT_TRUE(detail::detect_cpu().neon);
+}
+
+TEST(CpuFeatures, X86FeaturesAreNeverReportedOnArm) {
+    const detail::cpu_features& cpu = detail::detect_cpu();
+    EXPECT_FALSE(cpu.avx2);
+    EXPECT_FALSE(cpu.avx512);
+}
+
+#endif
+
+TEST(CpuFeatures, DispatchNeverOutrunsTheProbe) {
+    // The whole point of the probe: dispatch must not pick a backend the CPU
+    // cannot run. Restates the dispatch-side check from the probe's side, so a
+    // detection regression fails here even if dispatch is refactored.
+    const detail::cpu_features& cpu = detail::detect_cpu();
+    switch (active_backend<default_rounds>()) {
+        case backend::avx2:
+            EXPECT_TRUE(cpu.avx2);
+            break;
+        case backend::avx512:
+            EXPECT_TRUE(cpu.avx512);
+            break;
+        case backend::neon:
+            EXPECT_TRUE(cpu.neon);
+            break;
+        case backend::scalar:
+            SUCCEED();
+            break;
+    }
+}


### PR DESCRIPTION
Closes #35.

## Motivation

`cpu_features.hpp` stubbed MSVC to `false` for every feature, so **MSVC builds
ran the scalar kernel even on AVX2 hardware**. With the AVX2 kernel landing in
#73, that stub is the difference between Windows users getting a 3.3x kernel
and getting nothing.

## What changed

One CPUID + `XGETBV` probe, used on **every** x86 compiler rather than only on
MSVC:

| Step | Source |
|---|---|
| max-leaf guard | CPUID leaf 0, EAX >= 7 |
| OSXSAVE | leaf 1, ECX bit 27 |
| AVX2 | leaf 7 subleaf 0, EBX bit 5 |
| AVX512F / AVX512DQ | leaf 7 subleaf 0, EBX bits 16 / 17 |
| OS vector state | XCR0 bits 1,2 (YMM) and 5,6,7 (ZMM) |

`XGETBV` executes only after OSXSAVE is confirmed set, since it faults
otherwise. The XCR0 check is not optional detail: a CPU can report an
instruction set the OS never agreed to preserve across a context switch, and
using it then corrupts whatever runs next.

`_xgetbv` on GCC/Clang would need `-mxsave` on the whole build, so that side
uses two lines of raw asm instead. No build flags were added.

## Why one shared path instead of an MSVC branch

This is the part worth reviewing. MSVC has no `__builtin_cpu_supports`, so the
CPUID code is the *only* detection MSVC will ever have. If it lived behind
`#if defined(_MSC_VER)`, it would be exercised on exactly one runner — Windows
CI — which is the hardest place to debug a wrong bit position.

Making it the shared x86 path means every Linux and macOS run executes the same
code MSVC depends on, and `tests/test_cpu_features.cpp` asserts it agrees with
`__builtin_cpu_supports` wherever that builtin exists. A wrong leaf number, bit
index, or XCR0 mask now fails on a runner we can inspect.

The tradeoff is that this replaces working GCC/Clang detection. The
cross-check test is what makes that safe, and it runs on `linux-gcc`,
`linux-clang`, `linux-debug-werror`, `linux-asan`, and `linux-scalar`.

## Tests

New `tests/test_cpu_features.cpp` — 5 tests, none skipped on x86:

- `CpuidAgreesWithCompilerBuiltin` — the probe equals `__builtin_cpu_supports`
  for both AVX2 and AVX512F+DQ. This is the one that guards MSVC.
- `Avx512ImpliesXsaveEnabled` — an AVX-512 answer implies the full ZMM state mask.
- `ProbeIsCached` — `detect_cpu()` returns one stable reference.
- `NeonIsNeverReportedOnX86` / `NeonIsAlwaysPresentOnAarch64` — arch gating.
- `DispatchNeverOutrunsTheProbe` — restates the dispatch guarantee from the
  probe's side, so a detection regression fails here even if dispatch is
  refactored.

Developed on a host with **both** AVX2 and AVX512F/DQ, so both branches of the
cross-check were exercised non-trivially rather than passing by both being false.

```
cmake --preset default && cmake --build --preset default && ctest --preset default   # 45/45
cmake --preset debug   && cmake --build --preset debug   && ctest --preset debug     # 45/45, -Werror
cmake --preset asan    && cmake --build --preset asan    && ctest --preset asan      # 45/45
cmake --preset scalar  && cmake --build --preset scalar  && ctest --preset scalar    # 45/45
clang-format --dry-run --Werror over include tests benchmarks tools                   # clean
```

## Note on ordering

This branches from `master`, so it is independent of #73 and the two can merge
in either order. The full payoff arrives once both are in: on this PR alone,
`windows-msvc` proves the probe compiles and its own tests pass, but
`KernelParity.Avx2` still skips there because `master` has no AVX2 kernel yet.
Once #73 merges, Windows CI starts running the AVX2 parity matrix for real.

No bit-stream impact — this changes only which backend a machine selects, and
every backend is bit-for-bit identical by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
