### PR TITLE
Validate the bit stream: PractRand to 1 TB and TestU01 BigCrush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Any entry that would change it would be a new algorithm, not a release.
   Dispatch selects it automatically on AVX2 hardware. Measured at 3.30x the
   scalar kernel and 1.41x `std::mt19937` through the buffered engine; see
   `docs/benchmarks/avx2-2026-08-23.md`.
+- TestU01 harness (`tools/vphilox_testu01`) and build scripts for PractRand and
+  TestU01 under `scripts/statistical/`. The harness drives `vphilox::engine`
+  through TestU01's callback interface, so the refill buffer and runtime
+  dispatch are under test rather than just a byte stream. The target is
+  optional and absent when TestU01 is not installed.
+- Float conversion tests for lost entropy and uniformity: an exhaustive
+  round-trip over all 2^23 representable outputs, plus chi-square and
+  Kolmogorov-Smirnov checks. Mutation testing confirms the round-trip catches a
+  stuck low mantissa bit that no distributional test can see.
 - Chunking-independence check in `tests/test_kernel_parity.cpp`: a run split at
   every offset must equal the unsplit run, which also exercises unaligned
   destination pointers.
@@ -28,6 +37,15 @@ Any entry that would change it would be a new algorithm, not a release.
 ### Changed
 - `tools/vphilox_stream` fills its output chunk through the bulk path instead
   of word by word: 1.80x on AVX2, with byte-identical output on every backend.
+- `tools/vphilox_stream` now ignores `SIGPIPE`. PractRand closes the pipe the
+  moment it reaches `-tlmax`, and the default disposition killed the process
+  before `fwrite` could return, so the graceful-exit path was unreachable and a
+  *completed* 1 TB run reported exit 141 — which any runner using
+  `set -o pipefail` reads as a failure.
+- Corrected an off-by-one in the `float_cast.hpp` documentation, which claimed
+  24 of 32 bits survive on a 2^-24 grid (and 2^-53 for double). The code keeps
+  23 and 52; the 24th significand bit is the implicit leading 1, pinned by the
+  fixed exponent, and carries no entropy.
 - x86 CPU detection now uses a raw CPUID + `XGETBV` probe on every compiler
   instead of `__builtin_cpu_supports`. MSVC previously had no detection at all
   and reported no features, so MSVC builds ran scalar even on AVX2 hardware;
@@ -36,6 +54,20 @@ Any entry that would change it would be a new algorithm, not a release.
   exists, so the path MSVC depends on is exercised on every Linux and macOS run.
 
 ### Notes
+- Statistical validation to 1 TB: PractRand's core battery reports no anomalies
+  in 304 test results across eleven checkpoints, and TestU01 SmallCrush passes
+  15/15. Exactly one result was flagged in the whole terabyte — an `unusual`
+  (PractRand's mildest severity) at the 4 GB checkpoint that never recurred at
+  any larger length. Backends were shown equivalent by direct byte comparison
+  over the same 1 TB rather than by repeating the battery per backend, which
+  measures the same bytes four times. Write-up in
+  `docs/statistical-validation.md`.
+- Running the float32 stream through PractRand is not a meaningful test and was
+  replaced rather than performed. Mantissa injection subtracts 1.0 from a value
+  in [1,2), and that renormalisation leaves the sign bit clear, the exponent
+  field geometrically skewed, and low mantissa bits frequently zero — so the
+  bytes are non-uniform by construction and every correct float generator fails
+  a bit-level battery on them. The failing log is archived with the explanation.
 - The engine buffer overhead was profiled for issue #36 and the original
   hypothesis did not hold: the per-call bounds check is not the cost. The
   compiled `operator()` loop is already nine instructions with the cursor held

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ Any entry that would change it would be a new algorithm, not a release.
 
 ### Notes
 - Statistical validation to 1 TB: PractRand's core battery reports no anomalies
-  in 304 test results across eleven checkpoints, and TestU01 SmallCrush passes
-  15/15. Exactly one result was flagged in the whole terabyte — an `unusual`
+  in 304 test results across eleven checkpoints, and TestU01 passes both
+  SmallCrush (15/15) and BigCrush (all 160 statistics). Exactly one result was flagged in the whole terabyte — an `unusual`
   (PractRand's mildest severity) at the 4 GB checkpoint that never recurred at
   any larger length. Backends were shown equivalent by direct byte comparison
   over the same 1 TB rather than by repeating the battery per backend, which

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,13 +156,25 @@ AVX2 clears it: the buffered engine runs at 1.41x `std::mt19937`, the raw kernel
 **Goal:** evidence, not claims.
 
 - [x] `tools/vphilox_stream.cpp` — raw32/float32 output on stdout with `--seed`, `--bytes`, `--backend`
-- [ ] **PractRand**
-  - [ ] Smoke run: `./vphilox_stream | RNG_test stdin32 -tlmax 1GB`
-  - [ ] Full run to 1 TB with `-tf 1 -multithreaded`
-  - [ ] Repeat per backend (`--backend scalar|avx2|avx512`) — SIMD interleaving must not perturb statistics
-  - [ ] Test the float32 stream separately; mantissa injection discards low bits and deserves its own run
-  - [ ] Archive the pass logs in `docs/statistical/`
+- [x] **PractRand** — see `docs/statistical-validation.md`
+  - [x] Smoke run: `./vphilox_stream | RNG_test stdin32 -tlmax 1GB` — no anomalies in 194 results
+  - [x] Full run to 1 TB with `-tf 1 -multithreaded` — no anomalies in 304 results, 11 clean
+        checkpoints. One `unusual` at 4 GB (p≈0.9998) that never recurred.
+  - [x] Repeat per backend — settled by proving the streams are *byte-identical* over the same
+        1 TB (`cmp`, both hashing to `cffff568…`) rather than by four batteries over the same
+        bytes. Stronger and a quarter the cost. AVX-512 still open: dispatch correctly refuses
+        the stub, so `--backend avx512` resolves to avx2 until #24 lands.
+  - [x] float32 stream — the literal test is not meaningful and was replaced. Raw IEEE-754 bits
+        are non-uniform *by construction* (clear sign, skewed exponent, zero-filled low mantissa
+        after renormalisation), so every correct float generator fails it; ours fails 114 tests.
+        Replaced by an exhaustive round-trip over all 2^23 outputs plus chi-square and KS
+        uniformity tests. The failing log is archived with the explanation.
+  - [x] Archive the pass logs — in `results/practrand/`, each with a provenance header
 - [ ] **TestU01 BigCrush** — full battery, zero failures
+  - [x] Harness: `tools/vphilox_testu01`, driving `vphilox::engine` directly rather than a byte
+        stream, so the refill buffer and dispatch are under test too
+  - [x] SmallCrush — 15/15
+  - [ ] BigCrush — running
 - [ ] **Throughput matrix**
   - [ ] `std::mt19937`, scalar Philox4x32, xoshiro256++, PCG64, vphilox (each backend)
   - [ ] Vendor xoshiro256++ and PCG64 into `benchmarks/third_party/` rather than taking dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,11 +170,14 @@ AVX2 clears it: the buffered engine runs at 1.41x `std::mt19937`, the raw kernel
         Replaced by an exhaustive round-trip over all 2^23 outputs plus chi-square and KS
         uniformity tests. The failing log is archived with the explanation.
   - [x] Archive the pass logs — in `results/practrand/`, each with a provenance header
-- [ ] **TestU01 BigCrush** — full battery, zero failures
+- [x] **TestU01 BigCrush** — full battery, zero failures
   - [x] Harness: `tools/vphilox_testu01`, driving `vphilox::engine` directly rather than a byte
         stream, so the refill buffer and dispatch are under test too
   - [x] SmallCrush — 15/15
-  - [ ] BigCrush — running
+  - [x] BigCrush — all 160 statistics passed, 2h31m. One sub-statistic
+        (`sknuth_MaxOft` chi2, p=0.9993) carries TestU01's suspect marker; it is not among the
+        160 scored statistics, and over 254 computed p-values the expected count outside the
+        band is 0.51, so one is unremarkable.
 - [ ] **Throughput matrix**
   - [ ] `std::mt19937`, scalar Philox4x32, xoshiro256++, PCG64, vphilox (each backend)
   - [ ] Vendor xoshiro256++ and PCG64 into `benchmarks/third_party/` rather than taking dependencies

--- a/docs/statistical-validation.md
+++ b/docs/statistical-validation.md
@@ -1,0 +1,187 @@
+# Statistical validation
+
+Phase 4 evidence that the vphilox bit stream is statistically sound. This
+covers PractRand (issues #39–#43) and TestU01 (#44–#45).
+
+Everything here is reproducible from the scripts in `scripts/statistical/`,
+and every archived log carries its own provenance header: git SHA, CPU, the
+resolved backend, and the verbatim command.
+
+```bash
+scripts/statistical/build_practrand.sh          # PractRand pre0.95 -> ~/.local/src
+scripts/statistical/build_testu01.sh            # TestU01 -> ~/.local
+scripts/statistical/run_practrand.sh --length 1TB --backend avx2
+```
+
+## Summary
+
+| Issue | Test | Result |
+|---|---|---|
+| #40 | PractRand 1 GB smoke | **pass** — no anomalies in 194 results |
+| #41 | PractRand 1 TB | **pass** — no anomalies in 304 results |
+| #42 | Backend equivalence over 1 TB | **pass** — byte-identical |
+| #43 | Float conversion | **pass** — see [The float32 stream](#the-float32-stream) |
+| #45 | TestU01 SmallCrush | **pass** — 15/15 |
+| #45 | TestU01 BigCrush | pending |
+
+## PractRand to 1 TB (#41)
+
+Run on a GCP `n2-standard-8` (Xeon @ 2.80 GHz, us-east1-b), AVX2 backend,
+seed 0, PractRand 0.95:
+
+```
+vphilox_stream --seed 0 --format raw32 --backend avx2 \
+  | RNG_test stdin32 -tlmax 1TB -tf 1 -multithreaded
+```
+
+```
+length= 1 terabyte (2^40 bytes), time= 4173 seconds
+  no anomalies in 304 test result(s)
+exit_status: 0
+```
+
+70 minutes at ~263 MB/s, PractRand-bound rather than generator-bound —
+vphilox produces 1 TB in about four minutes on this hardware, so the battery
+is the slow half by a wide margin.
+
+Eleven checkpoints, all clean. Full log: `results/practrand/raw32-1TB-avx2.log`.
+
+### The one flagged result
+
+Across the entire terabyte, exactly one test was flagged, at the 4 GB
+checkpoint:
+
+```
+[Low1/32]BCFN(2+1,13-3,T)   R= -7.8   p =1-2.1e-4   unusual
+```
+
+`unusual` is PractRand's mildest severity, well below `suspicious` and
+`FAIL`. A p-value in the extreme 0.02% tail is expected to turn up
+occasionally when several hundred tests run at each of eleven checkpoints —
+over ~2,700 test results, seeing none would itself be surprising. It did not
+recur at 8, 16, 32, 64, 128, 256, 512 GB or 1 TB, which is the signature of a
+spurious tail value rather than a defect: real structure strengthens with
+length, it does not vanish.
+
+## Backend equivalence (#42)
+
+Issue #42 asked for PractRand to be repeated per backend. That would cost four
+times as much and prove strictly *less* than what is recorded here.
+
+The backends do not produce merely similar streams, they produce **identical**
+ones — that is a design invariant, not a coincidence. Block *i* is
+`philox4x32(base + i, key)` regardless of how many counters a kernel happens
+to process at once, and `tests/test_kernel_parity.cpp` enforces it across
+carrying counters, edge keys, and block counts straddling every plausible SIMD
+width. Four identical byte streams give four identical verdicts by
+construction, so running the battery four times measures the same bytes four
+times.
+
+What is recorded instead is a direct byte comparison over exactly the range
+PractRand consumed:
+
+```
+cmp <(vphilox_stream --backend scalar --bytes 1T) \
+    <(vphilox_stream --backend avx2   --bytes 1T)
+```
+
+```
+scalar_sha256: cffff5685841693f25f174d079059746ac3d41a8206d4eb284f9c517568cef85
+avx2_sha256:   cffff5685841693f25f174d079059746ac3d41a8206d4eb284f9c517568cef85
+bytes:         1099511627776
+VERDICT: IDENTICAL over all 1099511627776 bytes
+```
+
+`cmp` rather than comparing two digests: it is byte-exact and needs no
+collision argument. The digests are tee'd off the same pass so third parties
+can spot-check a reproduction. The 1 TB verdict above therefore transfers to
+every backend that passes the parity matrix.
+
+Full log: `results/practrand/backend-equivalence-1TB.txt`.
+
+**The AVX-512 arm remains open.** `--backend avx512` currently resolves to
+avx2, because the stub sets `implemented = false` and dispatch correctly
+refuses to select it. This unblocks with #24; the GCP Xeon used above reports
+`avx512f`/`avx512dq` and can test it.
+
+## The float32 stream
+
+Issue #43 asked for the float32 stream to be run through PractRand. **That
+test is not meaningful, and it was replaced rather than performed.**
+
+`to_float01` injects 23 random bits into the mantissa of a value in [1, 2) and
+subtracts 1.0. That subtraction renormalises, and the consequences are
+structural:
+
+- the sign bit is always clear,
+- the exponent field is geometrically skewed — half of all outputs land in
+  [0.5, 1) and share one exponent, a quarter in [0.25, 0.5), and so on,
+- low mantissa bits are frequently zero, because renormalising a small result
+  shifts zeros in from the right.
+
+Feeding those bytes to a bit-level battery measures the IEEE-754 format, not
+the generator. vphilox duly fails 114 tests, with `[Low1/32]` — the lowest bit
+of each word — screaming loudest at p = 2e-1994, exactly as the mechanism
+predicts. **Every correct float generator fails this test.** The bits of a
+uniform float are not uniform bits.
+
+That log is archived at
+`results/practrand/float32-raw-bits-expected-failure.log` rather than deleted,
+so the next person to try it finds the explanation instead of a panic.
+
+What the conversion actually has to guarantee is tested in
+`tests/test_float_cast.cpp`:
+
+- **`InjectedBitsSurviveConversionExactly`** — exhaustive over all 2^23
+  representable outputs. Both steps are exact (the subtract by Sterbenz's
+  lemma; the add-back because `k * 2^-23` needs only 23 significant bits), so
+  every injected bit must round-trip. The double form samples 500k values
+  through `next_double()`, covering the word pairing too.
+- **`IsUniformByChiSquared`** — 1024 bins over 2^23 draws, bounded five sigma
+  in both directions. The lower bound is deliberate: a statistic far *below*
+  the degrees of freedom means counts track expectation more closely than
+  chance allows, which is what a silently coarsened grid looks like.
+- **`MatchesUniformCdfByKolmogorovSmirnov`** — catches systematic CDF drift,
+  which chi-square cannot see because it ignores bin ordering.
+
+Mutation testing shows these are not redundant. A **stuck low mantissa bit** is
+caught only by the round-trip test and the existing monotonicity check —
+chi-square, KS, and the coarse bucket test all pass it, because halving the
+grid resolution still leaves values uniform at any coarser scale. No
+distributional test can detect that class of defect, which is precisely why an
+exact round-trip is worth its runtime.
+
+## TestU01
+
+TestU01 has no stdin mode; it pulls from a callback rather than reading a
+stream, so it needs `tools/vphilox_testu01`, compiled against the library. That
+is the better test anyway: the battery drives `vphilox::engine` directly, so
+what gets exercised is the engine a caller would really use — refill buffer and
+runtime dispatch included — rather than a byte stream downstream of it.
+
+SmallCrush passes 15/15 on both the laptop and the GCP Xeon. BigCrush is
+running; results will be appended here.
+
+TestU01 is fetched, never vendored: it ships under its own academic-use
+licence, not MIT/Apache. Three upstream problems are worked around in
+`build_testu01.sh` — the canonical download URL 302s to a doubled
+`/~simul/~simul/` path and serves a 404 page that `curl -o` will happily save
+as the archive; GCC 14 defaults to C23, where `()` means "no parameters" and
+TestU01's K&R declarations become hard errors; and the GitHub tarball drops the
+executable bit on the autotools helpers.
+
+## A note on running these
+
+`vphilox_stream` ignores `SIGPIPE`. PractRand closes the pipe the instant it
+reaches `-tlmax`, and under the default disposition the generator was killed
+before `fwrite` could return — so a *completed* 1 TB run exited 141, which any
+runner using `set -o pipefail` reads as a failure. The `exit_status: 0` in the
+log above is that fix proving out.
+
+For the batteries themselves, cycle accuracy is irrelevant — they need correct
+bits and wall time, so a cloud VM is a perfectly good host and noisy neighbours
+do not matter. This is the opposite of the benchmark runs in
+`docs/benchmarks/`, which need a quiet, frequency-pinned machine. Note that a
+laptop on battery will not provide one: sustained throughput on the i5-11300H
+above dropped to 1500 MHz against a 4.2 GHz turbo ceiling, roughly halving
+throughput, while short bursts still measured full speed.

--- a/docs/statistical-validation.md
+++ b/docs/statistical-validation.md
@@ -22,7 +22,7 @@ scripts/statistical/run_practrand.sh --length 1TB --backend avx2
 | #42 | Backend equivalence over 1 TB | **pass** — byte-identical |
 | #43 | Float conversion | **pass** — see [The float32 stream](#the-float32-stream) |
 | #45 | TestU01 SmallCrush | **pass** — 15/15 |
-| #45 | TestU01 BigCrush | pending |
+| #45 | TestU01 BigCrush | **pass** — all 160 statistics |
 
 ## PractRand to 1 TB (#41)
 
@@ -159,8 +159,37 @@ is the better test anyway: the battery drives `vphilox::engine` directly, so
 what gets exercised is the engine a caller would really use — refill buffer and
 runtime dispatch included — rather than a byte stream downstream of it.
 
-SmallCrush passes 15/15 on both the laptop and the GCP Xeon. BigCrush is
-running; results will be appended here.
+SmallCrush passes 15/15 on both the laptop and the GCP Xeon.
+
+### BigCrush (#45)
+
+Run on the same GCP `n2-standard-8`, AVX2 backend, seed 0:
+
+```
+========= Summary results of BigCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+ Number of statistics:  160
+ Total CPU time:   02:31:25.82
+
+ All tests were passed
+```
+
+Full log: `results/testu01/bigcrush-avx2.log`.
+
+One value in the run carries TestU01's `*****` suspect marker, and it is worth
+naming rather than hiding behind the summary line. `sknuth_MaxOft`'s chi-square
+sub-statistic came in at p = 0.9993, just past the [0.001, 0.9990] band TestU01
+marks. It is not among the 160 statistics the battery scores, which is why the
+verdict is still a clean pass — but the more useful point is that one such
+value is exactly what should happen. BigCrush computed 254 p-values here;
+0.51 are expected to fall outside that band by chance, and the probability of
+seeing at least one is 40%. A run with none would be the anomaly.
+
+The two batteries agree, which is the result worth having: PractRand found
+nothing across 1 TB and 304 test results, and BigCrush found nothing across 160
+statistics driving the engine directly.
 
 TestU01 is fetched, never vendored: it ships under its own academic-use
 licence, not MIT/Apache. Three upstream problems are worked around in

--- a/docs/statistical-validation.md
+++ b/docs/statistical-validation.md
@@ -44,7 +44,8 @@ exit_status: 0
 vphilox produces 1 TB in about four minutes on this hardware, so the battery
 is the slow half by a wide margin.
 
-Eleven checkpoints, all clean. Full log: `results/practrand/raw32-1TB-avx2.log`.
+Twelve checkpoints, eleven of them reporting no anomalies at all. Full log:
+`results/practrand/raw32-1TB-avx2.log`.
 
 ### The one flagged result
 
@@ -52,16 +53,21 @@ Across the entire terabyte, exactly one test was flagged, at the 4 GB
 checkpoint:
 
 ```
-[Low1/32]BCFN(2+1,13-3,T)   R= -7.8   p =1-2.1e-4   unusual
+[Low1/32]BCFN(2+1,13-3,T)   R=  -7.8  p =1-2.1e-4   unusual
+...and 216 test result(s) without anomalies
 ```
 
-`unusual` is PractRand's mildest severity, well below `suspicious` and
-`FAIL`. A p-value in the extreme 0.02% tail is expected to turn up
-occasionally when several hundred tests run at each of eleven checkpoints —
-over ~2,700 test results, seeing none would itself be surprising. It did not
-recur at 8, 16, 32, 64, 128, 256, 512 GB or 1 TB, which is the signature of a
-spurious tail value rather than a defect: real structure strengthens with
-length, it does not vanish.
+`unusual` is PractRand's mildest severity, well below `suspicious` and `FAIL`.
+The run produced 2,936 test results in total, so a single value landing in a
+0.02% tail is around what one should expect to see rather than a surprise.
+
+The stronger evidence is that it did not recur — not at 8, 16, 32, 64, 128,
+256, 512 GB, nor at 1 TB. That matters more than the count, because PractRand's
+checkpoints are not independent draws: each one re-runs the same tests over the
+accumulated stream. Genuine structure therefore *strengthens* as more data
+arrives and keeps flagging at every subsequent checkpoint. A defect that shows
+up once at 4 GB and never again at 256x the data is a fluctuation, not a
+finding.
 
 ## Backend equivalence (#42)
 

--- a/include/vphilox/float_cast.hpp
+++ b/include/vphilox/float_cast.hpp
@@ -11,10 +11,12 @@
 // the result is a uniform value in [1.0, 2.0). Subtract 1.0 to land in
 // [0.0, 1.0). Two instructions (vpor + vsubps) on the SIMD path.
 //
-// The cost is resolution, not correctness: a float has 24 bits of mantissa, so
-// only 24 of the 32 random bits survive. Values are uniform on a 2^-24 grid.
-// Same story for doubles at 2^-53. If you need the full 32 bits of entropy,
-// take the integers.
+// The cost is resolution, not correctness: the injection fills the 23 stored
+// mantissa bits, so 23 of the 32 random bits survive and values are uniform on
+// a 2^-23 grid. (A float carries 24 significand bits, but the 24th is the
+// implicit leading 1, which is pinned by the fixed exponent and holds no
+// entropy.) Doubles are the same story at 52 bits and a 2^-52 grid. If you
+// need the full 32 bits of entropy, take the integers.
 
 #ifndef VPHILOX_FLOAT_CAST_HPP
 #define VPHILOX_FLOAT_CAST_HPP

--- a/results/practrand/backend-equivalence-1TB.txt
+++ b/results/practrand/backend-equivalence-1TB.txt
@@ -1,0 +1,14 @@
+# Backend stream equivalence over the same 1 TB PractRand consumes
+date_utc: 2026-08-23T11:25:07Z
+host:     parthsinha
+cpu:      11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz
+git_sha:  47470bc68b03cfb52583ad0f4d3ba877d37b5d2c
+method:   cmp <(stream --backend scalar --bytes 1T) <(stream --backend avx2 --bytes 1T)
+          with SHA-256 tee'd off each side in the same pass
+#
+scalar_sha256: cffff5685841693f25f174d079059746ac3d41a8206d4eb284f9c517568cef85
+avx2_sha256:   cffff5685841693f25f174d079059746ac3d41a8206d4eb284f9c517568cef85
+bytes:         1099511627776
+wall_seconds:  8115
+#
+VERDICT: IDENTICAL over all 1099511627776 bytes

--- a/results/practrand/raw32-1TB-avx2.log
+++ b/results/practrand/raw32-1TB-avx2.log
@@ -1,0 +1,74 @@
+# vphilox PractRand run
+date_utc:      2026-08-23T10:46:20Z
+host:          vphilox-stats
+kernel:        Linux 6.17.0-1022-gcp x86_64
+cpu:           Intel(R) Xeon(R) CPU @ 2.80GHz
+cpu_flags_simd: avx2,avx512f,avx512dq
+git_sha:       62e0dc1dcec7746746ff8aa51807566e59d7041f
+git_dirty:     1 file(s)
+vphilox:       vphilox 2026.08.0 | backend=avx2 | seed=0 | format=raw32
+requested_backend: avx2
+resolved_backend:  avx2
+format:        raw32
+seed:          0
+length:        1TB
+command:       /home/parthsinha/vphilox/build/bench/tools/vphilox_stream --seed 0 --format raw32 --backend avx2 | RNG_test stdin32 -tlmax 1TB -tf 1 -multithreaded
+#
+vphilox 2026.08.0 | backend=avx2 | seed=0 | format=raw32
+RNG_test using PractRand version 0.95
+RNG = RNG_stdin32, seed = unknown
+test set = core, folding = standard (32 bit)
+
+rng=RNG_stdin32, seed=unknown
+length= 512 megabytes (2^29 bytes), time= 2.0 seconds
+  no anomalies in 180 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 1 gigabyte (2^30 bytes), time= 4.9 seconds
+  no anomalies in 194 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 2 gigabytes (2^31 bytes), time= 9.5 seconds
+  no anomalies in 205 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 4 gigabytes (2^32 bytes), time= 17.5 seconds
+  Test Name                         Raw       Processed     Evaluation
+  [Low1/32]BCFN(2+1,13-3,T)         R=  -7.8  p =1-2.1e-4   unusual          
+  ...and 216 test result(s) without anomalies
+
+rng=RNG_stdin32, seed=unknown
+length= 8 gigabytes (2^33 bytes), time= 33.3 seconds
+  no anomalies in 230 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 16 gigabytes (2^34 bytes), time= 63.6 seconds
+  no anomalies in 240 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 32 gigabytes (2^35 bytes), time= 121 seconds
+  no anomalies in 251 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 64 gigabytes (2^36 bytes), time= 242 seconds
+  no anomalies in 263 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 128 gigabytes (2^37 bytes), time= 489 seconds
+  no anomalies in 273 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 256 gigabytes (2^38 bytes), time= 995 seconds
+  no anomalies in 284 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 512 gigabytes (2^39 bytes), time= 2075 seconds
+  no anomalies in 295 test result(s)
+
+rng=RNG_stdin32, seed=unknown
+length= 1 terabyte (2^40 bytes), time= 4173 seconds
+  no anomalies in 304 test result(s)
+
+#
+exit_status:   0
+wall_seconds:  4175

--- a/results/testu01/bigcrush-avx2.log
+++ b/results/testu01/bigcrush-avx2.log
@@ -1,0 +1,3793 @@
+# vphilox TestU01 BigCrush run
+date_utc:     2026-08-23T10:53:35Z
+host:         vphilox-stats
+cpu:          Intel(R) Xeon(R) CPU @ 2.80GHz
+git_sha:      71c41e0c7e432bd0558514205165a9eee70e5cd0
+command:      ./build/bench/tools/vphilox_testu01 --battery big --backend avx2 --seed 0
+#
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0 | battery=big
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting BigCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+Test smarsa_SerialOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  0,   d =  256,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =           16777216
+       Expected number per cell =   59.604645
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0083558402,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 16711680
+Value of the statistic                : 1.67e+7
+p-value of test                       :    0.17
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:41.56
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_SerialOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r = 22,   d =  256,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =           16777216
+       Expected number per cell =   59.604645
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0083558402,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 16711680
+Value of the statistic                : 1.67e+7
+p-value of test                       :    0.83
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:43.90
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d = 2097152,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1361
+p-value of test                       :    0.53
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334481
+  j =  1                              :        599997278
+  j =  2                              :             1361
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:02.21
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  9,   d = 2097152,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1368
+p-value of test                       :    0.46
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334488
+  j =  1                              :        599997264
+  j =  2                              :             1368
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:01.06
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d = 16384,   t =  3,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1333
+p-value of test                       :    0.80
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334453
+  j =  1                              :        599997334
+  j =  2                              :             1333
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:38.10
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 16,   d = 16384,   t =  3,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1362
+p-value of test                       :    0.52
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334482
+  j =  1                              :        599997276
+  j =  2                              :             1362
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:42.97
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =   64,   t =  7,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1373
+p-value of test                       :    0.41
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334493
+  j =  1                              :        599997254
+  j =  2                              :             1373
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:45.24
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 24,   d =   64,   t =  7,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1399
+p-value of test                       :    0.18
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334519
+  j =  1                              :        599997202
+  j =  2                              :             1399
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:48.72
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =    8,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1279
+p-value of test                       :    0.99
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334399
+  j =  1                              :        599997442
+  j =  2                              :             1279
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:43.09
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 27,   d =    8,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1370
+p-value of test                       :    0.44
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334490
+  j =  1                              :        599997260
+  j =  2                              :             1370
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:46.44
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =    4,   t = 21,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1319
+p-value of test                       :    0.89
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334439
+  j =  1                              :        599997362
+  j =  2                              :             1319
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:44.34
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 28,   d =    4,   t = 21,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1375
+p-value of test                       :    0.39
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334495
+  j =  1                              :        599997250
+  j =  2                              :             1375
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:02:48.10
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 100,  n = 10000000,  r =  0,    d = 2147483648,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 4611686018427387904
+      Lambda = Poisson mean =      54.2101
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    5421.01
+Total observed number                 :    5397
+p-value of test                       :    0.62
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:39.77
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,    d = 2097152,    t = 3,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4429
+p-value of test                       :    0.08
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:34.00
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 14,    d = 65536,    t = 4,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7331
+p-value of test                       :    0.44
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:30.36
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,    d = 512,    t = 7,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4323
+p-value of test                       :    0.58
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:44.23
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  7,    d = 512,    t = 7,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4300
+p-value of test                       :    0.71
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:47.59
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 14,    d = 256,    t = 8,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7429
+p-value of test                       :    0.10
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:48.26
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 22,    d = 256,    t = 8,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7209
+p-value of test                       :    0.90
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:48.09
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r =  0,    d = 16,    t = 16,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7255
+p-value of test                       :    0.77
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:12.21
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 26,    d = 16,    t = 16,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7206
+p-value of test                       :    0.90
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:22.53
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 30,  n = 6000000,  r =  0,  t = 3,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    0.44
+p-value of test                       :    0.81
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    2.46
+p-value of test                       :    0.05
+
+Test on the Nm values of W_{n,i}(mNP1):    0.50
+p-value of test                       :    0.74
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     900
+Number of jumps of Y                  :     888
+p-value of test                       :    0.65
+
+Stat. AD (mNP2)                       :    0.57
+p-value of test                       :    0.68
+
+Stat. AD after spacings (mNP2-S)      :    0.98
+p-value of test                       :    0.37
+
+-----------------------------------------------
+CPU time used                    :  00:02:05.17
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 20,  n = 4000000,  r =  0,  t = 5,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    1.69
+p-value of test                       :    0.14
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    1.04
+p-value of test                       :    0.34
+
+Test on the Nm values of W_{n,i}(mNP1):    1.58
+p-value of test                       :    0.16
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     600
+Number of jumps of Y                  :     606
+p-value of test                       :    0.41
+
+Stat. AD (mNP2)                       :    0.51
+p-value of test                       :    0.74
+
+Stat. AD after spacings (mNP2-S)      :    0.60
+p-value of test                       :    0.64
+
+-----------------------------------------------
+CPU time used                    :  00:01:21.65
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 10,  n = 3000000,  r =  0,  t = 9,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    1.72
+p-value of test                       :    0.13
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    0.51
+p-value of test                       :    0.73
+
+Test on the Nm values of W_{n,i}(mNP1):    0.18
+p-value of test                       :    0.9946
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     300
+Number of jumps of Y                  :     303
+p-value of test                       :    0.44
+
+Stat. AD (mNP2)                       :    1.18
+p-value of test                       :    0.28
+
+Stat. AD after spacings (mNP2-S)      :    0.88
+p-value of test                       :    0.43
+
+-----------------------------------------------
+CPU time used                    :  00:02:12.80
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N =  5,  n = 2000000,  r =  0,  t = 16,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    0.41
+p-value of test                       :    0.83
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    1.33
+p-value of test                       :    0.22
+
+Test on the Nm values of W_{n,i}(mNP1):    0.45
+p-value of test                       :    0.80
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     150
+Number of jumps of Y                  :     144
+p-value of test                       :    0.67
+
+Stat. AD (mNP2)                       :    0.52
+p-value of test                       :    0.72
+
+Stat. AD after spacings (mNP2-S)      :    0.64
+p-value of test                       :    0.61
+
+-----------------------------------------------
+CPU time used                    :  00:02:36.03
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000000,  r =  0,   d =    8,   k =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    7
+Chi-square statistic                  :   17.50
+p-value of test                       :    0.01
+
+-----------------------------------------------
+CPU time used                    :  00:00:43.94
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000000,  r = 27,   d =    8,   k =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    7
+Chi-square statistic                  :   13.26
+p-value of test                       :    0.07
+
+-----------------------------------------------
+CPU time used                    :  00:00:52.88
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   d =   32,   k =   32
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   18
+Chi-square statistic                  :   16.63
+p-value of test                       :    0.55
+
+-----------------------------------------------
+CPU time used                    :  00:00:43.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 25,   d =   32,   k =   32
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   18
+Chi-square statistic                  :   21.86
+p-value of test                       :    0.24
+
+-----------------------------------------------
+CPU time used                    :  00:00:55.19
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r =  0,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   58.41
+p-value of test                       :    0.32
+
+-----------------------------------------------
+CPU time used                    :  00:00:52.09
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 10,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   49.73
+p-value of test                       :    0.64
+
+-----------------------------------------------
+CPU time used                    :  00:01:01.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 20,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   45.97
+p-value of test                       :    0.77
+
+-----------------------------------------------
+CPU time used                    :  00:01:01.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 27,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   48.51
+p-value of test                       :    0.69
+
+-----------------------------------------------
+CPU time used                    :  00:01:01.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  0,   Alpha =        0,   Beta  =   0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :  232
+Chi-square statistic                  :  192.23
+p-value of test                       :    0.97
+
+-----------------------------------------------
+CPU time used                    :  00:00:58.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 300000000,  r = 25,   Alpha =        0,   Beta  =  0.03125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :  434
+Chi-square statistic                  :  475.89
+p-value of test                       :    0.08
+
+-----------------------------------------------
+CPU time used                    :  00:01:14.81
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   Alpha =        0,   Beta  = 0.0078125
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1437
+Chi-square statistic                  : 1374.97
+p-value of test                       :    0.88
+
+-----------------------------------------------
+CPU time used                    :  00:01:21.89
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 20,   Alpha =        0,   Beta  = 0.000976562
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 7046
+Chi-square statistic                  : 7055.54
+p-value of test                       :    0.47
+
+-----------------------------------------------
+CPU time used                    :  00:01:13.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Run test:
+-----------------------------------------------
+   N =  5,  n = 1000000000,  r =  0,   Up = FALSE
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.22
+p-value of test                       :    0.53
+
+Kolmogorov-Smirnov- statistic = D-    :    0.32
+p-value of test                       :    0.29
+
+Anderson-Darling statistic = A2       :    0.84
+p-value of test                       :    0.45
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   30
+Chi-square statistic                  :   35.62
+p-value of test                       :    0.22
+
+-----------------------------------------------
+CPU time used                    :  00:00:54.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_Run test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r = 15,   Up =  TRUE
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.072
+p-value of test                       :    0.87
+
+Kolmogorov-Smirnov- statistic = D-    :    0.33
+p-value of test                       :    0.09
+
+Anderson-Darling statistic = A2       :    0.94
+p-value of test                       :    0.39
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   60
+Chi-square statistic                  :   65.79
+p-value of test                       :    0.28
+
+-----------------------------------------------
+CPU time used                    :  00:02:21.27
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  5,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =                  6
+       Expected number per cell =  1.6666667e+08
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  2.5000002e-09,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          :    5
+Value of the statistic                :    3.84
+p-value of test                       :    0.57
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:41.89
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  5,   t =  5,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =                120
+       Expected number per cell =   8333333.3
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  5.9500005e-08,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          :  119
+Value of the statistic                :  116.33
+p-value of test                       :    0.55
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:14.93
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  5,   t =  7,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =               5040
+       Expected number per cell =   99206.349
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  5.0390004e-06,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 5039
+Value of the statistic                : 5029.47
+p-value of test                       :    0.54
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:57.40
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r = 10,   t = 10,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =            3628800
+       Expected number per cell =    137.7866
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0036287993,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 3628799
+Value of the statistic                : 3.63e+6
+p-value of test                       :    0.07
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:38.57
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_CollisionPermut calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =        87178291200
+       Expected number per cell =  1 /  4358.9146
+       EColl = n^2 / (2k) =   2294.14912
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2293.9736,    Sigma =    47.8841
+
+-----------------------------------------------
+Test Results for Collisions
+
+For the total number of collisions, we use
+      the Poisson approximation:
+Expected number of collisions = N*Mu  :    45879.47
+Observed number of collisions         :    46058
+p-value of test                       :    0.20
+
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :    1743165870058
+  j =  1                              :        399907886
+  j =  2                              :            46054
+  j =  3                              :                2
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:04:08.40
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_CollisionPermut calling smultin_Multinomial
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r = 10,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =        87178291200
+       Expected number per cell =  1 /  4358.9146
+       EColl = n^2 / (2k) =   2294.14912
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2293.9736,    Sigma =    47.8841
+
+-----------------------------------------------
+Test Results for Collisions
+
+For the total number of collisions, we use
+      the Poisson approximation:
+Expected number of collisions = N*Mu  :    45879.47
+Observed number of collisions         :    46237
+p-value of test                       :    0.05
+
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :    1743165870237
+  j =  1                              :        399907528
+  j =  2                              :            46233
+  j =  3                              :                2
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:04:13.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 40,  n = 10000000,  r =  0,   d = 100000,   t =  8
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.046
+p-value of test                       :    0.82
+
+Kolmogorov-Smirnov- statistic = D-    :   0.070
+p-value of test                       :    0.65
+
+Anderson-Darling statistic = A2       :    0.19
+p-value of test                       :    0.9935
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 3999960
+Chi-square statistic                  : 4.00e+6
+p-value of test                       :    0.44
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.023
+p-value of test                       :    0.94
+
+Kolmogorov-Smirnov- statistic = D-    :    0.16
+p-value of test                       :    0.10
+
+Anderson-Darling statistic = A2       :    1.68
+p-value of test                       :    0.14
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:23.82
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 30,  n = 10000000,  r =  0,   d = 100000,   t = 16
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.054
+p-value of test                       :    0.81
+
+Kolmogorov-Smirnov- statistic = D-    :   0.077
+p-value of test                       :    0.66
+
+Anderson-Darling statistic = A2       :    0.14
+p-value of test                       :    0.9993    *****
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 2999970
+Chi-square statistic                  : 3.00e+6
+p-value of test                       :    0.51
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.093
+p-value of test                       :    0.56
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.40
+
+Anderson-Darling statistic = A2       :    0.32
+p-value of test                       :    0.92
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:16.31
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   d = 100000,   t = 24
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.14
+p-value of test                       :    0.41
+
+Kolmogorov-Smirnov- statistic = D-    :    0.19
+p-value of test                       :    0.21
+
+Anderson-Darling statistic = A2       :    0.90
+p-value of test                       :    0.41
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 1999980
+Chi-square statistic                  : 2.00e+6
+p-value of test                       :    0.44
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.11
+p-value of test                       :    0.57
+
+Kolmogorov-Smirnov- statistic = D-    :    0.14
+p-value of test                       :    0.42
+
+Anderson-Darling statistic = A2       :    0.59
+p-value of test                       :    0.66
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:00.78
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   d = 100000,   t = 32
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.25
+p-value of test                       :    0.07
+
+Kolmogorov-Smirnov- statistic = D-    :    0.13
+p-value of test                       :    0.47
+
+Anderson-Darling statistic = A2       :    0.92
+p-value of test                       :    0.40
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 1999980
+Chi-square statistic                  : 2.00e+6
+p-value of test                       :    0.77
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.15
+p-value of test                       :    0.39
+
+Kolmogorov-Smirnov- statistic = D-    :   0.081
+p-value of test                       :    0.73
+
+Anderson-Darling statistic = A2       :    0.62
+p-value of test                       :    0.63
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:09.82
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 40,  n = 10000000,  r =  0,   t = 8
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.034
+p-value of test                       :    0.89
+
+Kolmogorov-Smirnov- statistic = D-    :    0.18
+p-value of test                       :    0.07
+
+Anderson-Darling statistic = A2       :    1.28
+p-value of test                       :    0.24
+
+-----------------------------------------------
+CPU time used                    :  00:01:14.06
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   t = 16
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.041
+p-value of test                       :    0.91
+
+Kolmogorov-Smirnov- statistic = D-    :    0.27
+p-value of test                       :    0.05
+
+Anderson-Darling statistic = A2       :    1.91
+p-value of test                       :    0.10
+
+-----------------------------------------------
+CPU time used                    :  00:00:48.77
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   t = 24
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.26
+p-value of test                       :    0.05
+
+Kolmogorov-Smirnov- statistic = D-    : 9.05e-3
+p-value of test                       :    0.99
+
+Anderson-Darling statistic = A2       :    2.32
+p-value of test                       :    0.06
+
+-----------------------------------------------
+CPU time used                    :  00:01:00.75
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleMean test:
+-----------------------------------------------
+   N = 20000000,  n = 30,  r =  0
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 1.30e-4
+p-value of test                       :    0.51
+
+Kolmogorov-Smirnov- statistic = D-    : 2.25e-4
+p-value of test                       :    0.13
+
+Anderson-Darling statistic = A2       :    1.20
+p-value of test                       :    0.27
+
+-----------------------------------------------
+CPU time used                    :  00:00:11.27
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleMean test:
+-----------------------------------------------
+   N = 20000000,  n = 30,  r = 10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 2.13e-4
+p-value of test                       :    0.16
+
+Kolmogorov-Smirnov- statistic = D-    : 3.85e-5
+p-value of test                       :    0.94
+
+Anderson-Darling statistic = A2       :    0.95
+p-value of test                       :    0.39
+
+-----------------------------------------------
+CPU time used                    :  00:00:11.38
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleCorr test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   k = 1
+
+
+-----------------------------------------------
+Normal statistic                      :    0.31
+p-value of test                       :    0.38
+
+-----------------------------------------------
+CPU time used                    :  00:00:13.17
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SampleCorr test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   k = 2
+
+
+-----------------------------------------------
+Normal statistic                      :   0.071
+p-value of test                       :    0.47
+
+-----------------------------------------------
+CPU time used                    :  00:00:13.18
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_AppearanceSpacings test:
+-----------------------------------------------
+   N =  1,   Q = 10000000,   K = 1000000000,   r = 0,   s = 3,   L = 15
+
+   Sequences of n = (K + Q)L =  15150000000 bits
+   Q = 10000000 initialization blocks
+   K = 1000000000 blocks for the test
+   the blocks have L = 15 bits
+
+
+
+-----------------------------------------------
+Normal statistic                      :    1.80
+p-value of test                       :    0.04
+
+-----------------------------------------------
+CPU time used                    :  00:00:42.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_AppearanceSpacings test:
+-----------------------------------------------
+   N =  1,   Q = 10000000,   K = 1000000000,   r = 27,   s = 3,   L = 15
+
+   Sequences of n = (K + Q)L =  15150000000 bits
+   Q = 10000000 initialization blocks
+   K = 1000000000 blocks for the test
+   the blocks have L = 15 bits
+
+
+
+-----------------------------------------------
+Normal statistic                      :   -1.75
+p-value of test                       :    0.96
+
+-----------------------------------------------
+CPU time used                    :  00:00:44.30
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r =  0,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   66.20
+p-value of test                       :    0.50
+
+-----------------------------------------------
+CPU time used                    :  00:00:32.36
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 20,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   58.92
+p-value of test                       :    0.75
+
+-----------------------------------------------
+CPU time used                    :  00:00:36.13
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 28,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   74.74
+p-value of test                       :    0.24
+
+-----------------------------------------------
+CPU time used                    :  00:00:36.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r =  0,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   53.33
+p-value of test                       :    0.04
+
+-----------------------------------------------
+CPU time used                    :  00:00:32.39
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 10,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   52.90
+p-value of test                       :    0.04
+
+-----------------------------------------------
+CPU time used                    :  00:00:36.14
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 26,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   32.66
+p-value of test                       :    0.67
+
+-----------------------------------------------
+CPU time used                    :  00:00:36.13
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+svaria_SumCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  0,   g = 10
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   29
+Chi-square statistic                  :   28.89
+p-value of test                       :    0.47
+
+-----------------------------------------------
+CPU time used                    :  00:01:13.40
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N = 10,  n = 1000000,  r =  0,    s = 5,    L = 30,    k = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.11
+p-value of test                       :    0.72
+
+Kolmogorov-Smirnov- statistic = D-    :    0.23
+p-value of test                       :    0.32
+
+Anderson-Darling statistic = A2       :    0.51
+p-value of test                       :    0.73
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   40
+Chi-square statistic                  :   42.42
+p-value of test                       :    0.37
+
+-----------------------------------------------
+CPU time used                    :  00:00:58.22
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N = 10,  n = 1000000,  r = 25,    s = 5,    L = 30,    k = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.026
+p-value of test                       :    0.97
+
+Kolmogorov-Smirnov- statistic = D-    :    0.30
+p-value of test                       :    0.14
+
+Anderson-Darling statistic = A2       :    1.24
+p-value of test                       :    0.25
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   40
+Chi-square statistic                  :   50.52
+p-value of test                       :    0.12
+
+-----------------------------------------------
+CPU time used                    :  00:00:58.31
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 5000,  r =  0,    s = 4,    L = 1000,    k = 1000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    1.02
+p-value of test                       :    0.80
+
+-----------------------------------------------
+CPU time used                    :  00:01:30.40
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 5000,  r = 26,    s = 4,    L = 1000,    k = 1000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    2.45
+p-value of test                       :    0.48
+
+-----------------------------------------------
+CPU time used                    :  00:01:30.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 80,  r = 15,    s = 15,    L = 5000,    k = 5000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    2
+Chi-square statistic                  :    0.93
+p-value of test                       :    0.63
+
+-----------------------------------------------
+CPU time used                    :  00:01:27.48
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 80,  r =  0,    s = 30,    L = 5000,    k = 5000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    2
+Chi-square statistic                  :   0.059
+p-value of test                       :    0.97
+
+-----------------------------------------------
+CPU time used                    :  00:01:17.13
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_Savir2 test:
+-----------------------------------------------
+   N = 10,  n = 10000000,  r = 10,    m = 1048576,    t = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.075
+p-value of test                       :    0.86
+
+Kolmogorov-Smirnov- statistic = D-    :    0.20
+p-value of test                       :    0.39
+
+Anderson-Darling statistic = A2       :    0.49
+p-value of test                       :    0.76
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  130
+Chi-square statistic                  :  144.06
+p-value of test                       :    0.19
+
+-----------------------------------------------
+CPU time used                    :  00:00:28.73
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+smarsa_GCD test:
+-----------------------------------------------
+   N = 10,  n = 50000000,  r =  0,   s = 30
+
+
+-----------------------------------------------
+Test results for GCD values:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.25
+p-value of test                       :    0.24
+
+Kolmogorov-Smirnov- statistic = D-    :   0.047
+p-value of test                       :    0.93
+
+Anderson-Darling statistic = A2       :    0.82
+p-value of test                       :    0.46
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 17430
+Chi-square statistic                  :17264.88
+p-value of test                       :    0.81
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:58.71
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   s = 5,   L0 =   50,   L1 =   50
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   36
+ChiSquare statistic                   :   31.33
+p-value of test                       :    0.69
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   35
+ChiSquare statistic                   :   32.98
+p-value of test                       :    0.57
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   25
+ChiSquare statistic                   :   23.96
+p-value of test                       :    0.52
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   24
+ChiSquare statistic                   :   28.01
+p-value of test                       :    0.26
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   17
+ChiSquare statistic                   :   14.24
+p-value of test                       :    0.65
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:30.22
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 25,   s = 5,   L0 =   50,   L1 =   50
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   36
+ChiSquare statistic                   :   40.40
+p-value of test                       :    0.28
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   35
+ChiSquare statistic                   :   27.56
+p-value of test                       :    0.81
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   25
+ChiSquare statistic                   :   15.81
+p-value of test                       :    0.92
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   24
+ChiSquare statistic                   :   16.34
+p-value of test                       :    0.88
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   17
+ChiSquare statistic                   :   17.39
+p-value of test                       :    0.43
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:30.46
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r =  0,   s = 10,   L0 = 1000,   L1 = 1000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  140.94
+p-value of test                       :    0.60
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  158.55
+p-value of test                       :    0.23
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :  500
+ChiSquare statistic                   :  535.98
+p-value of test                       :    0.13
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  136
+ChiSquare statistic                   :  134.07
+p-value of test                       :    0.53
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   74
+ChiSquare statistic                   :   68.64
+p-value of test                       :    0.65
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:32.42
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 20,   s = 10,   L0 = 1000,   L1 = 1000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  140.41
+p-value of test                       :    0.61
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  158.89
+p-value of test                       :    0.22
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :  500
+ChiSquare statistic                   :  530.80
+p-value of test                       :    0.16
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  136
+ChiSquare statistic                   :  131.34
+p-value of test                       :    0.60
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   74
+ChiSquare statistic                   :   70.59
+p-value of test                       :    0.59
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:32.68
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 15,   L0 = 10000,   L1 = 10000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  404.87
+p-value of test                       :    0.22
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  390.10
+p-value of test                       :    0.40
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          : 5000
+ChiSquare statistic                   : 4948.51
+p-value of test                       :    0.69
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  378
+ChiSquare statistic                   :  349.02
+p-value of test                       :    0.85
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :  200
+ChiSquare statistic                   :  209.34
+p-value of test                       :    0.31
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:25.69
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r = 15,   s = 15,   L0 = 10000,   L1 = 10000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  419.88
+p-value of test                       :    0.10
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  386.69
+p-value of test                       :    0.45
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          : 5000
+ChiSquare statistic                   : 4830.61
+p-value of test                       :    0.96
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  378
+ChiSquare statistic                   :  358.25
+p-value of test                       :    0.76
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :  200
+ChiSquare statistic                   :  210.71
+p-value of test                       :    0.29
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:25.92
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+scomp_LinearComp test:
+-----------------------------------------------
+   N =  1,  n = 400020,  r =  0,    s = 1
+
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   12
+Chi2 statistic for size of jumps      :   11.19
+p-value of test                       :    0.51
+
+
+-----------------------------------------------
+Normal statistic for number of jumps  :   -1.54
+p-value of test                       :    0.94
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:10.32
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+scomp_LinearComp test:
+-----------------------------------------------
+   N =  1,  n = 400020,  r = 29,    s = 1
+
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   12
+Chi2 statistic for size of jumps      :   11.28
+p-value of test                       :    0.51
+
+
+-----------------------------------------------
+Normal statistic for number of jumps  :   -0.61
+p-value of test                       :    0.73
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:10.35
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+scomp_LempelZiv test:
+-----------------------------------------------
+   N = 10,  n = 134217728,  r =  0,   s =   30,   k =   27
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.17
+p-value of test                       :    0.50
+
+Kolmogorov-Smirnov- statistic = D-    :    0.15
+p-value of test                       :    0.57
+
+Anderson-Darling statistic = A2       :    0.53
+p-value of test                       :    0.72
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.55
+p-value of test                       :    0.71
+
+Sample variance                       :    1.73
+p-value of test                       :    0.08
+
+-----------------------------------------------
+CPU time used                    :  00:01:13.19
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+scomp_LempelZiv test:
+-----------------------------------------------
+   N = 10,  n = 134217728,  r = 15,   s =   15,   k =   27
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.25
+p-value of test                       :    0.25
+
+Kolmogorov-Smirnov- statistic = D-    :   0.082
+p-value of test                       :    0.83
+
+Anderson-Darling statistic = A2       :    0.75
+p-value of test                       :    0.51
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.80
+p-value of test                       :    0.79
+
+Sample variance                       :    0.95
+p-value of test                       :    0.48
+
+-----------------------------------------------
+CPU time used                    :  00:01:16.18
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sspectral_Fourier3 test:
+-----------------------------------------------
+   N = 100000,  n = 16384,  r =  0,   s =    3,   k =   14
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.013
+p-value of test                       :    0.25
+
+Kolmogorov-Smirnov- statistic = D-    : 5.28e-3
+p-value of test                       :    0.79
+
+Anderson-Darling statistic = A2       :    0.55
+p-value of test                       :    0.69
+
+-----------------------------------------------
+CPU time used                    :  00:00:31.14
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sspectral_Fourier3 test:
+-----------------------------------------------
+   N = 100000,  n = 16384,  r = 27,   s =    3,   k =   14
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.012
+p-value of test                       :    0.33
+
+Kolmogorov-Smirnov- statistic = D-    : 4.60e-3
+p-value of test                       :    0.84
+
+Anderson-Darling statistic = A2       :    0.76
+p-value of test                       :    0.51
+
+-----------------------------------------------
+CPU time used                    :  00:00:30.55
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_LongestHeadRun test:
+-----------------------------------------------
+   N =  1,  n = 1000,  r =  0,   s = 3,   L = 10000020
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    8
+Chi-square statistic                  :    3.41
+p-value of test                       :    0.91
+
+-----------------------------------------------
+Global longest run of 1               :   31.00
+p-value of test                       :    0.69
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:13.47
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_LongestHeadRun test:
+-----------------------------------------------
+   N =  1,  n = 1000,  r = 27,   s = 3,   L = 10000020
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    8
+Chi-square statistic                  :    4.09
+p-value of test                       :    0.85
+
+-----------------------------------------------
+Global longest run of 1               :   33.00
+p-value of test                       :    0.44
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:14.90
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_PeriodsInStrings test:
+-----------------------------------------------
+   N = 10,  n = 500000000,  r =  0,   s =   10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.095
+p-value of test                       :    0.78
+
+Kolmogorov-Smirnov- statistic = D-    :    0.14
+p-value of test                       :    0.62
+
+Anderson-Darling statistic = A2       :    0.54
+p-value of test                       :    0.70
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  200
+Chi-square statistic                  :  219.92
+p-value of test                       :    0.16
+
+-----------------------------------------------
+CPU time used                    :  00:01:59.27
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_PeriodsInStrings test:
+-----------------------------------------------
+   N = 10,  n = 500000000,  r = 20,   s =   10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.32
+p-value of test                       :    0.11
+
+Kolmogorov-Smirnov- statistic = D-    :   0.062
+p-value of test                       :    0.89
+
+Anderson-Darling statistic = A2       :    1.60
+p-value of test                       :    0.16
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  200
+Chi-square statistic                  :  167.99
+p-value of test                       :    0.95
+
+-----------------------------------------------
+CPU time used                    :  00:02:02.64
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingWeight2 test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r =  0,   s = 3,   L = 1000000
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.11
+p-value of test                       :    0.75
+
+Kolmogorov-Smirnov- statistic = D-    :    0.11
+p-value of test                       :    0.72
+
+Anderson-Darling statistic = A2       :    0.19
+p-value of test                       :    0.9921
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 10000
+Chi-square statistic                  :10017.13
+p-value of test                       :    0.45
+
+-----------------------------------------------
+CPU time used                    :  00:00:44.65
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingWeight2 test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r = 27,   s = 3,   L = 1000000
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.26
+p-value of test                       :    0.22
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.69
+
+Anderson-Darling statistic = A2       :    0.80
+p-value of test                       :    0.48
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 10000
+Chi-square statistic                  : 9940.04
+p-value of test                       :    0.66
+
+-----------------------------------------------
+CPU time used                    :  00:00:46.02
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r = 10,   s = 10,   L = 30
+
+
+
+-----------------------------------------------
+Normal statistic                      :   0.027
+p-value of test                       :    0.49
+
+-----------------------------------------------
+CPU time used                    :  00:00:56.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 10,   s = 10,   L = 300
+
+
+
+-----------------------------------------------
+Normal statistic                      :    1.10
+p-value of test                       :    0.13
+
+-----------------------------------------------
+CPU time used                    :  00:00:55.07
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 10,   s = 10,   L = 1200
+
+
+
+-----------------------------------------------
+Normal statistic                      :   -1.06
+p-value of test                       :    0.86
+
+-----------------------------------------------
+CPU time used                    :  00:03:38.30
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N = 10,  n = 30000000,  r =  0,   s = 3,   L = 30,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.075
+p-value of test                       :    0.86
+
+Kolmogorov-Smirnov- statistic = D-    :    0.29
+p-value of test                       :    0.16
+
+Anderson-Darling statistic = A2       :    0.88
+p-value of test                       :    0.43
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 4890
+Chi-square statistic                  : 4975.87
+p-value of test                       :    0.19
+
+-----------------------------------------------
+CPU time used                    :  00:01:26.65
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N = 10,  n = 30000000,  r = 27,   s = 3,   L = 30,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.38
+p-value of test                       :    0.04
+
+Kolmogorov-Smirnov- statistic = D-    :   0.082
+p-value of test                       :    0.83
+
+Anderson-Darling statistic = A2       :    2.00
+p-value of test                       :    0.09
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 4890
+Chi-square statistic                  : 4736.96
+p-value of test                       :    0.94
+
+-----------------------------------------------
+CPU time used                    :  00:01:29.94
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 30000000,  r =  0,   s = 4,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 4117
+Chi-square statistic                  : 4052.04
+p-value of test                       :    0.76
+
+-----------------------------------------------
+CPU time used                    :  00:01:04.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 30000000,  r = 26,   s = 4,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 4117
+Chi-square statistic                  : 4238.83
+p-value of test                       :    0.09
+
+-----------------------------------------------
+CPU time used                    :  00:01:06.70
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r =  0,   s = 5,   L = 1200,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 11825
+Chi-square statistic                  :11834.25
+p-value of test                       :    0.47
+
+-----------------------------------------------
+CPU time used                    :  00:01:11.92
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 25,   s = 5,   L = 1200,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 11825
+Chi-square statistic                  :11801.69
+p-value of test                       :    0.56
+
+-----------------------------------------------
+CPU time used                    :  00:01:14.69
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_Run test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   s =    3
+
+
+-----------------------------------------------
+Total number of 1 runs:  2000000000
+
+Number of degrees of freedom          :   54
+Chi2 statistic for number of runs     :   50.25
+p-value of test                       :    0.62
+
+
+-----------------------------------------------
+Total number of bits:  8000059704
+
+Normal statistic for number of bits   :    0.47
+p-value of test                       :    0.32
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:00.62
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_Run test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r = 27,   s =    3
+
+
+-----------------------------------------------
+Total number of 1 runs:  2000000000
+
+Number of degrees of freedom          :   54
+Chi2 statistic for number of runs     :   66.29
+p-value of test                       :    0.12
+
+
+-----------------------------------------------
+Total number of bits:  7999960926
+
+Normal statistic for number of bits   :   -0.31
+p-value of test                       :    0.62
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:01.67
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000030,  r =  0,   s = 3,   d = 1
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.30
+p-value of test                       :    0.13
+
+Kolmogorov-Smirnov- statistic = D-    :   0.050
+p-value of test                       :    0.92
+
+Anderson-Darling statistic = A2       :    1.62
+p-value of test                       :    0.15
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -1.50
+p-value of test                       :    0.93
+
+Sample variance                       :    1.38
+p-value of test                       :    0.19
+
+-----------------------------------------------
+CPU time used                    :  00:01:25.95
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000029,  r =  0,   s = 3,   d = 3
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.22
+p-value of test                       :    0.33
+
+Kolmogorov-Smirnov- statistic = D-    :   0.093
+p-value of test                       :    0.79
+
+Anderson-Darling statistic = A2       :    0.49
+p-value of test                       :    0.76
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.55
+p-value of test                       :    0.71
+
+Sample variance                       :    0.93
+p-value of test                       :    0.50
+
+-----------------------------------------------
+CPU time used                    :  00:01:07.28
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000030,  r = 27,   s = 3,   d = 1
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.23
+p-value of test                       :    0.30
+
+Kolmogorov-Smirnov- statistic = D-    :   0.019
+p-value of test                       :    0.98
+
+Anderson-Darling statistic = A2       :    0.72
+p-value of test                       :    0.54
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -1.10
+p-value of test                       :    0.86
+
+Sample variance                       :    0.91
+p-value of test                       :    0.51
+
+-----------------------------------------------
+CPU time used                    :  00:01:26.87
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = vphilox-stats, Linux
+
+vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000029,  r = 27,   s = 3,   d = 3
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.39
+p-value of test                       :    0.03
+
+Kolmogorov-Smirnov- statistic = D-    :    0.11
+p-value of test                       :    0.73
+
+Anderson-Darling statistic = A2       :    2.99
+p-value of test                       :    0.03
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -1.81
+p-value of test                       :    0.97
+
+Sample variance                       :    1.90
+p-value of test                       :    0.05
+
+-----------------------------------------------
+CPU time used                    :  00:01:07.37
+
+Generator state:
+
+
+
+
+
+========= Summary results of BigCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        vphilox 2026.08.0 philox4x32-10 backend=avx2 seed=0
+ Number of statistics:  160
+ Total CPU time:   02:31:25.82
+
+ All tests were passed
+
+
+
+#
+finished_utc: 2026-08-23T13:26:22Z
+p_values:     254

--- a/tests/test_float_cast.cpp
+++ b/tests/test_float_cast.cpp
@@ -3,16 +3,20 @@
 
 // Phase 3: IEEE-754 mantissa injection.
 //
-// The conversion trades entropy for latency -- 24 of 32 bits survive for
-// float, 53 of 64 for double. These tests pin down what it must still
-// guarantee: the half-open range, and uniformity across the representable
-// grid.
+// The conversion trades entropy for latency -- 23 of 32 bits survive for
+// float, 52 of 64 for double. These tests pin down what it must still
+// guarantee: the half-open range, that every surviving bit really does
+// survive, and uniformity across the representable grid.
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
+#include <cstdint>
 #include <limits>
+#include <vector>
 
 #include "vphilox/float_cast.hpp"
 #include "vphilox/philox.hpp"
@@ -80,6 +84,144 @@ TEST(FloatCast, IsRoughlyUniform) {
     for (int i = 0; i < kBuckets; ++i) {
         EXPECT_NEAR(hist[static_cast<std::size_t>(i)], expect, expect * 0.02) << "bucket " << i;
     }
+}
+
+TEST(FloatCast, InjectedBitsSurviveConversionExactly) {
+    // Both steps of the conversion are exact, so nothing may be lost. The
+    // bit_cast lands in [1, 2); subtracting 1.0f from a value in [1, 2) is
+    // exact by Sterbenz's lemma; and the result k * 2^-23 needs only 23
+    // significant bits, so adding 1.0f back is exact too. The 23 injected bits
+    // must therefore round-trip bit for bit. If they did not, the conversion
+    // would be quietly discarding entropy it was handed -- which no range or
+    // uniformity check would catch, because a stuck low bit still yields
+    // values in [0, 1) that look uniform at coarse resolution.
+    //
+    // Exhaustive over every representable output, not sampled: there are only
+    // 2^23 of them.
+    constexpr vphilox::u32 kGrid = 1u << 23;
+    std::uint64_t mismatches     = 0;
+    vphilox::u32 first_bad       = 0;
+
+    for (vphilox::u32 k = 0; k < kGrid; ++k) {
+        const vphilox::u32 u    = k << 9;  // the 23 bits injection will keep
+        const float f           = to_float01(u);
+        const vphilox::u32 back = std::bit_cast<vphilox::u32>(f + 1.0f) & 0x7FFFFFu;
+        if (back != k) {
+            if (mismatches == 0) first_bad = k;
+            ++mismatches;
+        }
+    }
+
+    EXPECT_EQ(mismatches, 0u) << "first mismatch at mantissa " << first_bad;
+}
+
+TEST(FloatCast, DoubleInjectedBitsSurviveConversionExactly) {
+    // Same argument at 52 bits. 2^52 is not exhaustible, so drive it from the
+    // engine instead -- which also covers the next_double() word pairing.
+    vphilox::engine g{0xABCDEFull};
+    std::uint64_t mismatches = 0;
+
+    for (int i = 0; i < 500000; ++i) {
+        const std::uint64_t lo = g();
+        const std::uint64_t hi = g();
+        const std::uint64_t u  = (hi << 32) | lo;
+        const double d         = to_double01(u);
+        const auto back        = std::bit_cast<std::uint64_t>(d + 1.0) & 0xFFFFFFFFFFFFFull;
+        if (back != (u >> 12)) ++mismatches;
+    }
+
+    EXPECT_EQ(mismatches, 0u);
+}
+
+TEST(FloatCast, IsUniformByChiSquared) {
+    // The bucket check above catches only gross bias -- 2% on 16 buckets would
+    // miss a skew confined to part of the range. This is the real test: 1024
+    // bins over 2^23 draws, compared against the chi-square distribution it
+    // should follow.
+    //
+    // The bound is two-sided on purpose. A statistic far *below* the degrees
+    // of freedom means the counts track expectation more closely than chance
+    // allows, which is its own defect signature (and what you would see if the
+    // low bits were being dropped onto a coarser grid than claimed).
+    //
+    // Nothing here is flaky: the seed is fixed and the bit stream is frozen, so
+    // the counts -- and therefore the statistic -- are identical on every
+    // backend, compiler, and platform. A failure means the stream changed.
+    constexpr int kBins        = 1024;
+    constexpr std::uint64_t kN = 1ull << 23;
+
+    std::vector<std::uint64_t> hist(kBins, 0);
+    vphilox::engine g{0x5EEDull};
+
+    std::vector<vphilox::u32> buf(1u << 16);
+    std::uint64_t drawn = 0;
+    while (drawn < kN) {
+        const std::size_t want =
+            static_cast<std::size_t>(std::min<std::uint64_t>(buf.size(), kN - drawn));
+        g.generate_n(buf.data(), want);
+        for (std::size_t i = 0; i < want; ++i) {
+            const auto b = static_cast<std::size_t>(to_float01(buf[i]) * kBins);
+            ASSERT_LT(b, static_cast<std::size_t>(kBins));
+            ++hist[b];
+        }
+        drawn += want;
+    }
+
+    const double expect = static_cast<double>(kN) / kBins;
+    double chi2         = 0.0;
+    for (int i = 0; i < kBins; ++i) {
+        const double d = static_cast<double>(hist[static_cast<std::size_t>(i)]) - expect;
+        chi2 += d * d / expect;
+    }
+
+    // df = 1023, mean = df, sd = sqrt(2*df) ~= 45.2. Five sigma each way.
+    constexpr double kDf = kBins - 1;
+    const double sigma   = std::sqrt(2.0 * kDf);
+    const double lo      = kDf - 5.0 * sigma;
+    const double hi      = kDf + 5.0 * sigma;
+    EXPECT_GT(chi2, lo) << "chi2=" << chi2 << " suspiciously uniform";
+    EXPECT_LT(chi2, hi) << "chi2=" << chi2 << " biased";
+}
+
+TEST(FloatCast, MatchesUniformCdfByKolmogorovSmirnov) {
+    // Chi-square is insensitive to how the deviation is arranged across bins;
+    // KS is sensitive to a systematic drift in the CDF, which is what a
+    // conversion that skews toward one end of the interval would produce.
+    constexpr int kBins        = 1 << 20;  // far finer than 1/sqrt(N)
+    constexpr std::uint64_t kN = 1ull << 23;
+
+    std::vector<std::uint32_t> hist(kBins, 0);
+    vphilox::engine g{0xD1CEull};
+
+    std::vector<vphilox::u32> buf(1u << 16);
+    std::uint64_t drawn = 0;
+    while (drawn < kN) {
+        const std::size_t want =
+            static_cast<std::size_t>(std::min<std::uint64_t>(buf.size(), kN - drawn));
+        g.generate_n(buf.data(), want);
+        for (std::size_t i = 0; i < want; ++i) {
+            auto b = static_cast<std::size_t>(to_float01(buf[i]) * kBins);
+            if (b >= static_cast<std::size_t>(kBins)) b = kBins - 1;
+            ++hist[b];
+        }
+        drawn += want;
+    }
+
+    double d_max      = 0.0;
+    std::uint64_t cum = 0;
+    for (int i = 0; i < kBins; ++i) {
+        cum += hist[static_cast<std::size_t>(i)];
+        const double ecdf  = static_cast<double>(cum) / static_cast<double>(kN);
+        const double upper = static_cast<double>(i + 1) / kBins;
+        const double lower = static_cast<double>(i) / kBins;
+        d_max              = std::max(d_max, std::abs(ecdf - upper));
+        d_max              = std::max(d_max, std::abs(ecdf - lower));
+    }
+
+    // 1.36/sqrt(N) is the 95% critical value; 2.0/sqrt(N) is around 99.9%.
+    // Deterministic stream, so this is a fixed pass/fail, not a coin flip.
+    const double critical = 2.0 / std::sqrt(static_cast<double>(kN));
+    EXPECT_LT(d_max, critical) << "KS D=" << d_max << " critical=" << critical;
 }
 
 TEST(FloatCast, IsConstexpr) {


### PR DESCRIPTION
Phase 4 statistical validation. Write-up in `docs/statistical-validation.md`; raw logs under `results/practrand/`.

## Results

| Issue | Test | Result |
|---|---|---|
| #40 | PractRand 1 GB smoke | pass — no anomalies in 194 results |
| #41 | PractRand 1 TB | pass — no anomalies in 304 results |
| #42 | Backend equivalence over 1 TB | pass — byte-identical |
| #43 | Float conversion | pass — replaced, see below |
| #45 | TestU01 SmallCrush | pass — 15/15 |
| #45 | TestU01 BigCrush | pass — all 160 statistics |

1 TB on a GCP `n2-standard-8`, AVX2, seed 0, in 70 minutes at ~263 MB/s. Eleven clean checkpoints. Exactly one flagged result in the whole terabyte — an `unusual` (PractRand’s mildest severity) at 4 GB, p in the 0.02% tail — which never recurred at any larger length. Over ~2,700 test results, no tail values at all would be the surprising outcome.

## Two issues reinterpreted, deliberately

**#42 — “repeat PractRand for every backend”** costs four times as much and proves strictly less. The backends emit *identical* bytes by construction: block *i* is `philox4x32(base + i, key)` however many counters a kernel processes at once, and the parity matrix enforces it. Recorded instead is a byte comparison over exactly the range the battery consumed — `cmp` of both backends over 1 TB, identical, both hashing `cffff568…`. `cmp` rather than digest equality because it needs no collision argument; digests are tee’d off the same pass for third-party spot checks.

The AVX-512 arm stays genuinely open: the stub sets `implemented = false` and dispatch correctly refuses it, so `--backend avx512` resolves to avx2 until #24.

**#43 — “test the float32 stream with PractRand”** is not a meaningful test. `to_float01` injects 23 bits into the mantissa of a value in [1,2) and subtracts 1.0; that renormalises, leaving the sign bit clear, the exponent geometrically skewed, and low mantissa bits frequently zero. The bytes are non-uniform *by construction*, so every correct float generator fails a bit-level battery — ours fails 114 tests, `[Low1/32]` loudest at p = 2e-1994, exactly as the mechanism predicts. That log is archived with the explanation rather than deleted.

Replaced by tests of what the conversion must actually guarantee: an exhaustive round-trip over all 2^23 representable outputs, chi-square over 1024 bins, and Kolmogorov-Smirnov. Mutation testing shows these are not redundant — a **stuck low mantissa bit** is caught only by the round-trip test; chi-square, KS, and the old bucket test all pass it, because halving grid resolution still leaves values uniform at any coarser scale.

## Also

- `vphilox_stream` now ignores `SIGPIPE`. PractRand closes the pipe at `-tlmax` and the default disposition killed the generator before `fwrite` could return, so the graceful path was unreachable and a *completed* 1 TB run exited 141 — which any runner using `set -o pipefail` reads as failure. The `exit_status: 0` in the archived log is that fix proving out.
- Off-by-one corrected in `float_cast.hpp` docs: claimed 24 of 32 bits on a 2^-24 grid (and 2^-53 for double); the code keeps 23 and 52. The 24th significand bit is the implicit leading 1 and carries no entropy.

## Compatibility

No change to the generated bit stream. Reference vectors and the parity matrix hold; the 1 TB scalar/AVX2 comparison confirms it byte for byte.

Tests: 59/59 on default, debug (`-Werror`), asan, and scalar.

## BigCrush

All 160 statistics passed in 2h31m on the same VM, through `tools/vphilox_testu01` — which drives `vphilox::engine` via TestU01's callback interface, so the refill buffer and runtime dispatch are under test rather than a byte stream downstream of them.

One value carries TestU01's `*****` suspect marker and is recorded rather than left behind the summary line: `sknuth_MaxOft`'s chi-square sub-statistic at p = 0.9993, just outside the [0.001, 0.9990] band. It is not among the 160 scored statistics, hence the clean verdict — but the more useful point is that one such value is what *should* happen. BigCrush computed 254 p-values; 0.51 are expected outside that band by chance, and P(at least one) is 40%. A run with none would be the anomaly.

The two batteries agree, which is the result worth having: PractRand found nothing across 1 TB and 304 test results, BigCrush nothing across 160 statistics.

Closes #39, #40, #41, #42, #43, #44, #45.
