### PR TITLE
Dispatch float conversion by ISA and add the bulk float path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Any entry that would change it would be a new algorithm, not a release.
 ## [Unreleased]
 
 ### Added
+- Bulk float generation: `generate_n(float*, count)` and
+  `generate(std::span<float>)`, equivalent to the same number of
+  `next_float()` calls in both output and resulting engine state. Roughly 2x
+  the word-at-a-time path; see `docs/benchmarks/float-conversion-2026-08-24.md`
+  for why the exact figure is not recorded yet.
+- `detail/float_bulk.hpp`: the u32 -> float conversion loop compiled twice,
+  once at the consumer's baseline ISA and once under `VPHILOX_TARGET("avx2")`,
+  selected by the same CPU probe and `VPHILOX_BACKEND` override as the
+  kernels. No intrinsics: the compiler already emits
+  `vpsrld` / `vpor` / `vaddps` for the plain loop, so the target attribute is
+  the only part that was missing. Conversion is elementwise, so all widths are
+  bit-identical and the choice never affects the stream.
 - Seeding from a `std::seed_seq`: `basic_engine(Sseq&)` and `seed(Sseq&)`,
   alongside a matching `seed(u64)`, so `std::mt19937 rng(seq)` call sites port
   by changing the type and nothing else. Only the key is drawn -- two words,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,19 @@ AVX2 clears it: the buffered engine runs at 1.41x `std::mt19937`, the raw kernel
 - [x] `detail/cpu_features.hpp` — raw CPUID + `XGETBV` probe, one shared x86 path, computed once
 - [x] `detail/dispatch.hpp` — resolves to the fastest kernel that is compiled in **and** implemented **and** CPU-supported
 - [x] `VPHILOX_BACKEND` env override for pinning a backend in tests and benchmarks
-- [ ] SIMD float conversion — `_mm256_or_si256` + `_mm256_sub_ps` and the AVX-512/NEON equivalents, keeping conversion inside vector registers
+- [~] SIMD float conversion — `_mm256_or_si256` + `_mm256_sub_ps` and the AVX-512/NEON equivalents, keeping conversion inside vector registers
+  - [x] **No intrinsics needed.** GCC already emits `vpsrld`/`vpor`/`vaddps` for the plain
+        `to_float01` loop; hand-writing them would be transcription and would freeze the width
+        at 8 where the loop widens on its own. See
+        [`docs/benchmarks/float-conversion-2026-08-24.md`](docs/benchmarks/float-conversion-2026-08-24.md)
+  - [x] The real gap was the ISA, not the instructions: header-only means the loop compiles
+        with the *consumer's* flags, so `detail/float_bulk.hpp` compiles it twice — baseline and
+        `VPHILOX_TARGET("avx2")` — and selects at runtime like the kernels do
+  - [x] Bulk float API to consume it: `generate_n(float*, n)` / `generate(std::span<float>)`,
+        equivalent to the same number of `next_float()` calls, ~2x that path
+  - [ ] AVX-512 / NEON variants — blocked on #24 and #28, not on hardware access
+  - [ ] Decide whether to fuse conversion into the kernels and remove the second pass.
+        Needs a frequency-pinned host: this laptop put the cost anywhere between 10% and 26%
 - [x] MSVC CPU detection (`__cpuidex` leaf 7 + `XGETBV` OS-state check) — no longer stubbed to `false`.
       The CPUID probe is now the single x86 path on every compiler, so Linux and macOS runs
       exercise the same code MSVC depends on; `tests/test_cpu_features.cpp` checks it against

--- a/benchmarks/bench_float.cpp
+++ b/benchmarks/bench_float.cpp
@@ -11,6 +11,7 @@
 #include <benchmark/benchmark.h>
 
 #include <random>
+#include <span>
 #include <vector>
 
 #include "vphilox/vphilox.hpp"
@@ -69,6 +70,39 @@ void BM_double_mantissa_injection(benchmark::State& state) {
     state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations() * kCount));
 }
 BENCHMARK(BM_double_mantissa_injection);
+
+// ---------------------------------------------------------------------------
+// Issue #34: the bulk float path against the word-at-a-time one, with the raw
+// integer bulk path as the ceiling. The gap between the last two is what the
+// conversion pass costs -- the part that only fusing conversion into the
+// kernels themselves could remove.
+// ---------------------------------------------------------------------------
+
+void BM_float_bulk(benchmark::State& state) {
+    vphilox::engine g{1};
+    std::vector<float> out(kCount);
+    for (auto _ : state) {
+        g.generate(std::span<float>{out});
+        benchmark::DoNotOptimize(out.data());
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations() * kCount));
+    state.SetBytesProcessed(static_cast<std::int64_t>(state.iterations() * kCount * 4));
+}
+BENCHMARK(BM_float_bulk);
+
+void BM_u32_bulk_ceiling(benchmark::State& state) {
+    vphilox::engine g{1};
+    std::vector<vphilox::u32> out(kCount);
+    for (auto _ : state) {
+        g.generate(std::span<vphilox::u32>{out});
+        benchmark::DoNotOptimize(out.data());
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations() * kCount));
+    state.SetBytesProcessed(static_cast<std::int64_t>(state.iterations() * kCount * 4));
+}
+BENCHMARK(BM_u32_bulk_ceiling);
 
 }  // namespace
 

--- a/docs/benchmarks/float-conversion-2026-08-24.md
+++ b/docs/benchmarks/float-conversion-2026-08-24.md
@@ -1,0 +1,109 @@
+# Bulk float conversion — 2026-08-24
+
+Issue #34, which asked for "SIMD float conversion — `_mm256_or_si256` +
+`_mm256_sub_ps` and the AVX-512/NEON equivalents, keeping conversion inside
+vector registers".
+
+Two findings, one of them a non-result: the intrinsics were already there, and
+this host cannot measure what remains.
+
+## The intrinsics were already being emitted
+
+`to_float01` is `bit_cast<float>(0x3F800000 | (u >> 9)) - 1.0f`. Compiled as a
+plain loop at `-O3 -mavx2`, GCC 15 produces:
+
+```
+.L4:
+    vmovdqu (%rdi,%rax), %ymm0
+    vpsrld  $9, %ymm0, %ymm0
+    vpor    %ymm1, %ymm0, %ymm0
+    vaddps  %ymm0, %ymm2, %ymm0     # ymm2 = -1.0f
+    vmovups %ymm0, (%rsi,%rax)
+    addq    $32, %rax
+    cmpq    %rax, %rcx
+    jne     .L4
+```
+
+That is the sequence the issue asks for, eight lanes wide, with an SSE tail
+after it. `vaddps` of `-1.0f` is GCC's canonical form of `- 1.0f`; it is the
+same instruction count and the same cost as `vsubps`. Hand-written intrinsics
+would be transcription, and they would freeze the width at 8 where the plain
+loop widens on its own (it emits SSE2 at plain `-O3`, and would emit 512-bit
+under `-mavx512f`).
+
+## What was actually missing: the ISA, not the intrinsics
+
+vphilox is header-only, so that loop compiles with whatever flags the
+*consumer's* translation unit carries. A consumer building at `-O2` with no
+`-mavx2` got SSE2 conversion while the AVX2 kernel still ran at full width,
+because the kernel carries `[[gnu::target("avx2")]]` with it and the
+conversion carried nothing.
+
+So `detail/float_bulk.hpp` compiles the same loop twice — once at the
+consumer's baseline, once under `VPHILOX_TARGET("avx2")` — and picks between
+them with the same CPU probe and the same `VPHILOX_BACKEND` override the
+kernels use. Verified: a plain loop inside a `target("avx2")` function
+auto-vectorises to full AVX2 even when the translation unit has no `-mavx2`.
+
+The conversion is elementwise and branch-free, so every width produces
+bit-identical output. `BulkGenerateFloat.ConversionWidthsAgreeBitForBit`
+asserts that against a length deliberately chosen not to be a vector multiple.
+
+## The number this document cannot give you
+
+`engine::generate_n(float*, n)` generates into a 1 KiB L1-resident tile and
+converts out of it. The conversion is a second pass over every word, which is
+exactly the cost that `generate_n(u32*, n)` was introduced to remove for
+integers (see `buffer-overhead-2026-08-23.md`). The prize for fusing
+conversion into the kernels themselves is the gap between the float bulk path
+and the raw integer bulk path, and `bench_float` measures it directly.
+
+**It was not measurable here.** The host is a Core i5-8400H under WSL2 with no
+governor control, and sustained AVX2 throttles it hard. Four pinned runs
+(`taskset -c 3`, 9 repetitions, 2 s minimum), in order:
+
+| Run | word-at-a-time | float bulk | u32 bulk | bulk / word | bulk / u32 |
+|---|---:|---:|---:|---:|---:|
+| 1 | 436.5 M/s | 869.6 M/s | 980.5 M/s | 1.99x | 88.7% |
+| 2 | 437.1 M/s | 878.3 M/s | 970.5 M/s | 2.01x | 90.5% |
+| 3 | 311.5 M/s | 237.9 M/s | 264.3 M/s | 0.76x | 90.0% |
+| 4 | 112.4 M/s | 291.5 M/s | 395.4 M/s | 2.59x | 73.7% |
+| 5 | 351.0 M/s | 611.3 M/s | 747.0 M/s | 1.74x | 81.8% |
+
+Within-run coefficients of variation were all under 0.3%, which is the trap:
+each run is internally stable and they disagree with each other by a factor of
+four. Runs 1 and 2 agree and are presumably the un-throttled truth. Run 3 puts
+the word-at-a-time path *ahead* of the bulk path, which cannot be true and
+means its rows were sampled at different points on a thermal ramp. Runs 4 and
+5 are throttled to different degrees, and the ratio that actually matters
+tracks them: it falls with absolute throughput (90.5% at 970 M/s, 81.8% at
+747 M/s, 73.7% at 395 M/s). Whatever that relationship is, it is a property
+of this host's clock behaviour and not of the code.
+
+So the honest summary is:
+
+- **Bulk float is about 2x the word-at-a-time path.** Robust across every
+  usable run.
+- **The conversion pass costs somewhere between 10% and 26% of integer bulk
+  throughput.** Not pinned down, and the spread is thermal, not algorithmic.
+
+If the real figure is near 10%, fusing conversion into the kernels is a much
+weaker lever than the refill buffer was (42% on AVX2) and probably not worth
+four backend-specific float entry points. If it is near 26%, it is worth
+reconsidering. **Re-run on a frequency-pinned machine before deciding** — the
+same class of host used for `avx512-baseline` would do.
+
+## Reproducing
+
+```sh
+cmake --preset bench
+cmake --build --preset bench --target bench_float
+taskset -c 3 build/bench/benchmarks/bench_float \
+  --benchmark_min_time=2s --benchmark_repetitions=9 \
+  --benchmark_report_aggregates_only=true \
+  --benchmark_filter='bulk|float_mantissa'
+```
+
+Discard any run whose rows are not in the order
+`u32 bulk > float bulk > word-at-a-time`; that ordering is structural, and a
+run that violates it was throttling mid-sample.

--- a/include/vphilox/detail/float_bulk.hpp
+++ b/include/vphilox/detail/float_bulk.hpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Parth Sinha
+
+// vphilox - detail/float_bulk.hpp
+//
+// Bulk u32 -> float conversion, vectorised by the compiler rather than by hand.
+//
+// Issue #34 asked for _mm256_or_si256 + _mm256_sub_ps spelled out. Measuring
+// first showed there is nothing to spell: GCC turns the plain loop below into
+//
+//     vmovdqu / vpsrld $9 / vpor / vaddps -1.0f / vmovups
+//
+// which is that sequence exactly, vaddps of -1.0f being the canonical form of
+// "- 1.0f". Intrinsics here would be transcription, not optimisation, and they
+// would freeze the width at 8 where the loop widens on its own.
+//
+// What the plain loop cannot do on its own is choose an ISA. vphilox is
+// header-only, so this loop compiles with whatever flags the *consumer's*
+// translation unit carries: someone building at -O2 with no -mavx2 gets SSE2
+// conversion while the AVX2 kernel still runs, because the kernel carries its
+// target attribute with it. So the loop is duplicated under VPHILOX_TARGET and
+// picked at runtime, the same way the kernels are. The attribute is what makes
+// it AVX2 -- the vectorising is the compiler's job either way.
+//
+// The conversion is elementwise and branch-free, so every width produces
+// bit-identical output. Which variant runs is a speed decision, never a stream
+// decision.
+
+#ifndef VPHILOX_DETAIL_FLOAT_BULK_HPP
+#define VPHILOX_DETAIL_FLOAT_BULK_HPP
+
+#include <cstddef>
+
+#include "vphilox/config.hpp"
+#include "vphilox/detail/dispatch.hpp"
+#include "vphilox/float_cast.hpp"
+
+namespace vphilox::detail {
+
+using float_convert_fn = void (*)(const u32*, float*, std::size_t) noexcept;
+
+/// Baseline conversion: whatever the consumer's translation unit targets.
+inline void to_float01_n_baseline(const u32* src, float* dst, std::size_t n) noexcept {
+    for (std::size_t i = 0; i < n; ++i) dst[i] = to_float01(src[i]);
+}
+
+#if VPHILOX_HAS_AVX2
+/// The identical loop, compiled for AVX2 regardless of the consumer's flags.
+VPHILOX_TARGET("avx2")
+inline void to_float01_n_avx2(const u32* src, float* dst, std::size_t n) noexcept {
+    for (std::size_t i = 0; i < n; ++i) dst[i] = to_float01(src[i]);
+}
+#endif
+
+/// Resolve the conversion once per process.
+///
+/// Gated on the same CPU probe and the same VPHILOX_BACKEND override as the
+/// kernels: pinning a backend has to pin the whole path, or a benchmark that
+/// says "scalar" would still be converting eight lanes at a time.
+inline float_convert_fn resolve_float_convert() noexcept {
+    static const float_convert_fn fn = []() -> float_convert_fn {
+#if VPHILOX_HAS_AVX2
+        bool has_override    = false;
+        const backend forced = backend_override(has_override);
+        if (has_override && forced != backend::avx2 && forced != backend::avx512) {
+            return &to_float01_n_baseline;
+        }
+        if (detect_cpu().avx2) return &to_float01_n_avx2;
+#endif
+        return &to_float01_n_baseline;
+    }();
+    return fn;
+}
+
+}  // namespace vphilox::detail
+
+#endif  // VPHILOX_DETAIL_FLOAT_BULK_HPP

--- a/include/vphilox/philox.hpp
+++ b/include/vphilox/philox.hpp
@@ -21,6 +21,7 @@
 #include "vphilox/constants.hpp"
 #include "vphilox/counter.hpp"
 #include "vphilox/detail/dispatch.hpp"
+#include "vphilox/detail/float_bulk.hpp"
 #include "vphilox/float_cast.hpp"
 
 namespace vphilox {
@@ -30,6 +31,12 @@ namespace vphilox {
 /// a refill.
 inline constexpr std::size_t refill_blocks = 8;
 inline constexpr std::size_t refill_words  = refill_blocks * block_words;
+
+/// Words converted per pass in the bulk float path. 256 words is 1 KiB of
+/// stack that stays resident in L1 across the generate/convert pair, and 64
+/// blocks -- comfortably past every backend's preferred_blocks, so the
+/// generating half always takes the direct path.
+inline constexpr std::size_t float_tile_words = 256;
 
 namespace detail {
 
@@ -148,6 +155,36 @@ public:
 
     /// Span form of `generate_n`.
     void generate(std::span<result_type> dst) noexcept { generate_n(dst.data(), dst.size()); }
+
+    /// Fill `count` floats in [0, 1), equivalent to `count` next_float()
+    /// calls in both output and resulting engine state.
+    ///
+    /// Generation and conversion are separate passes because nothing else is
+    /// available: the kernels write integers, so the bytes have to be read
+    /// back to be converted. The pass is kept off the caller's array and onto
+    /// a 1 KiB tile instead -- converting in place over `dst` would touch it
+    /// three times (write, read, write) where the tile touches it once, and
+    /// the tile itself never leaves L1.
+    ///
+    /// Fusing the conversion into the kernels would remove the pass outright,
+    /// and `bench_float` measures the prize: the gap between this and
+    /// `generate_n(u32*)`. It has not been measured on a machine that can
+    /// hold a clock -- see docs/benchmarks/float-conversion-2026-08-24.md.
+    void generate_n(float* dst, std::size_t count) noexcept {
+        const detail::float_convert_fn convert = detail::resolve_float_convert();
+
+        u32 tile[float_tile_words];
+        while (count != 0) {
+            const std::size_t n = std::min(count, float_tile_words);
+            generate_n(tile, n);
+            convert(tile, dst, n);
+            dst += n;
+            count -= n;
+        }
+    }
+
+    /// Span form of the bulk float path.
+    void generate(std::span<float> dst) noexcept { generate_n(dst.data(), dst.size()); }
 
     /// Uniform float in [0, 1) via mantissa injection.
     [[nodiscard]] float next_float() noexcept { return to_float01((*this)()); }

--- a/tests/test_bulk_generate.cpp
+++ b/tests/test_bulk_generate.cpp
@@ -123,10 +123,16 @@ TEST(BulkGenerate, HandlesZeroAndDoesNotTouchTheEngine) {
     const u32 first = g();
 
     engine same{5ull};
-    same.generate_n(nullptr, 0);
+    // Typed rather than a bare nullptr: generate_n is overloaded on u32* and
+    // float*, so an untyped null is ambiguous by construction.
+    same.generate_n(static_cast<u32*>(nullptr), 0);
     EXPECT_EQ(same(), first);
 
     same.generate(std::span<u32>{});
+    EXPECT_EQ(same(), g());
+
+    same.generate_n(static_cast<float*>(nullptr), 0);
+    same.generate(std::span<float>{});
     EXPECT_EQ(same(), g());
 }
 
@@ -184,4 +190,124 @@ TEST(BulkGenerate, RequestSpanningManyRefillsStaysInOrder) {
     std::vector<u32> got(n);
     g.generate(std::span<u32>{got});
     EXPECT_EQ(got, reference);
+}
+
+// ---------------------------------------------------------------------------
+// The float bulk path. Same contract, one conversion further on: `n` floats
+// must equal `n` next_float() calls and leave the engine where they would.
+// The seams that matter here are the 256-word conversion tile boundaries,
+// which do not line up with the 32-word refill boundaries.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// The reference stream: `n` floats straight out of next_float().
+std::vector<float> floats_by_call(u64 seed, std::size_t n) {
+    engine g{seed};
+    std::vector<float> out(n);
+    for (auto& f : out) f = g.next_float();
+    return out;
+}
+
+}  // namespace
+
+TEST(BulkGenerateFloat, MatchesNextFloatAcrossTileBoundaries) {
+    // Either side of the 256-word tile and the 32-word refill, plus a size
+    // that is a multiple of neither.
+    constexpr std::size_t sizes[] = {0, 1, 31, 32, 33, 255, 256, 257, 512, 700, 4097};
+    for (std::size_t n : sizes) {
+        const auto reference = floats_by_call(0xF10Aull, n);
+
+        engine g{0xF10Aull};
+        std::vector<float> got(n);
+        g.generate_n(got.data(), n);
+
+        ASSERT_EQ(got.size(), reference.size());
+        for (std::size_t i = 0; i < n; ++i) {
+            // Bit-exact, not approximate: this is the same arithmetic twice.
+            EXPECT_EQ(got[i], reference[i]) << "n=" << n << " word " << i;
+        }
+    }
+}
+
+TEST(BulkGenerateFloat, LeavesTheEngineWhereNextFloatWould) {
+    constexpr std::size_t n = 1000;
+
+    engine bulk{7ull};
+    std::vector<float> sink(n);
+    bulk.generate_n(sink.data(), n);
+
+    engine stepped{7ull};
+    for (std::size_t i = 0; i < n; ++i) static_cast<void>(stepped.next_float());
+
+    // Not counter(): that is the kernel's next counter, and the two engines
+    // legitimately disagree on it. The bulk path consumed 250 blocks and left
+    // nothing buffered; the stepped one consumed 256 and is holding 24 words
+    // in hand. What has to match is the stream from here on -- long enough to
+    // cross several refills, so a stale buffer would show up.
+    for (int i = 0; i < 300; ++i) EXPECT_EQ(bulk(), stepped()) << "word " << i;
+}
+
+TEST(BulkGenerateFloat, MixesWithSingleValueCalls) {
+    engine mixed{99ull};
+    engine reference{99ull};
+
+    std::vector<float> chunk(300);
+    for (int i = 0; i < 5; ++i) static_cast<void>(mixed.next_float());
+    mixed.generate(std::span<float>{chunk});
+    for (int i = 0; i < 5; ++i) static_cast<void>(mixed.next_float());
+
+    for (int i = 0; i < 5; ++i) static_cast<void>(reference.next_float());
+    for (auto& f : chunk) EXPECT_EQ(f, reference.next_float());
+    for (int i = 0; i < 5; ++i) static_cast<void>(reference.next_float());
+
+    EXPECT_EQ(mixed(), reference());
+}
+
+TEST(BulkGenerateFloat, StaysInTheUnitInterval) {
+    constexpr std::size_t n = 100'000;
+    engine g{3ull};
+    std::vector<float> out(n);
+    g.generate(std::span<float>{out});
+
+    for (std::size_t i = 0; i < n; ++i) {
+        ASSERT_GE(out[i], 0.0f) << "index " << i;
+        ASSERT_LT(out[i], 1.0f) << "index " << i;
+    }
+}
+
+TEST(BulkGenerateFloat, DoesNotWriteBeyondTheRequest) {
+    constexpr std::size_t n     = 257;  // one past a tile
+    constexpr std::size_t slack = 16;
+    const float guard           = -1.0f;
+
+    std::vector<float> buf(n + slack, guard);
+    engine g{1ull};
+    g.generate_n(buf.data(), n);
+
+    for (std::size_t i = n; i < buf.size(); ++i) {
+        EXPECT_EQ(buf[i], guard) << "clobbered float " << i;
+    }
+}
+
+// The two conversion variants are the same loop at two widths. Since the
+// conversion is elementwise, they must agree bit for bit -- the ISA choice is
+// a speed decision, never a stream decision.
+TEST(BulkGenerateFloat, ConversionWidthsAgreeBitForBit) {
+#if VPHILOX_HAS_AVX2
+    if (!detail::detect_cpu().avx2) GTEST_SKIP() << "no AVX2 on this CPU";
+
+    constexpr std::size_t n = 4096 + 5;  // deliberately not a vector multiple
+    std::vector<u32> src(n);
+    engine g{0xABCDull};
+    g.generate(std::span<u32>{src});
+
+    std::vector<float> baseline(n), wide(n);
+    detail::to_float01_n_baseline(src.data(), baseline.data(), n);
+    detail::to_float01_n_avx2(src.data(), wide.data(), n);
+
+    EXPECT_EQ(baseline, wide);
+#else
+    GTEST_SKIP() << "AVX2 not compiled in";
+#endif
 }


### PR DESCRIPTION
Issue #34 asked for _mm256_or_si256 + _mm256_sub_ps written out. GCC already emits vpsrld / vpor / vaddps for the plain to_float01 loop, so intrinsics here would be transcription, and they would freeze the width at 8 where the loop widens on its own.

The real gap was the ISA, not the instructions. vphilox is header-only, so that loop compiles with the consumer's flags: a consumer building at -O2 with no -mavx2 got SSE2 conversion while the AVX2 kernel still ran at full width, because the kernel carries its target attribute and the conversion carried nothing. detail/float_bulk.hpp compiles the loop twice -- baseline and VPHILOX_TARGET("avx2") -- and selects with the same CPU probe and VPHILOX_BACKEND override the kernels use.

Conversion is elementwise, so all widths are bit-identical and the choice never affects the stream; asserted directly against a length that is not a vector multiple.

Adds generate_n(float*, n) and generate(std::span<float>) to consume it, equivalent to the same number of next_float() calls in output and resulting engine state. Generation and conversion are separate passes onto a 1 KiB L1-resident tile rather than three passes over the caller's array.

About 2x the word-at-a-time path. The cost of the conversion pass -- the prize for fusing conversion into the kernels -- could not be pinned down here: this host throttles under sustained AVX2 and put it anywhere between 10% and 26%. Recorded with all five runs in docs/benchmarks/float-conversion-2026-08-24.md; needs a frequency-pinned machine to settle.

AVX-512 and NEON conversion variants remain open, blocked on #24 and #28 rather than on hardware.

Note: generate_n is now overloaded, so a bare generate_n(nullptr, 0) is ambiguous and needs a typed null. The u32 bulk API is itself unreleased, so nothing shipped is affected. The generated bit stream is untouched.

Refs #34