### PR TITLE
Add xoshiro256++ and PCG64 to the throughput matrix

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -194,15 +194,23 @@ AVX2 clears it: the buffered engine runs at 1.41x `std::mt19937`, the raw kernel
         (`sknuth_MaxOft` chi2, p=0.9993) carries TestU01's suspect marker; it is not among the
         160 scored statistics, and over 254 computed p-values the expected count outside the
         band is 0.51, so one is unremarkable.
-- [ ] **Throughput matrix**
-  - [ ] `std::mt19937`, scalar Philox4x32, xoshiro256++, PCG64, vphilox (each backend)
+- [~] **Throughput matrix**
+  - [x] `std::mt19937`, scalar Philox4x32, xoshiro256++, PCG64, vphilox (each backend, pinned
+        with `VPHILOX_BACKEND`) — all wired into `bench_engines.cpp`. Every row generates the
+        same 256 KiB rather than the same number of calls, so the 64-bit generators are not
+        handed twice the output for the same loop count
   - [x] Vendor xoshiro256++ and PCG64 into `benchmarks/third_party/` rather than taking dependencies
     - [x] Byte-for-byte upstream with SHA-256s recorded; vendored files are exempt from
           clang-format and the SPDX convention, since reformatting them would void the hashes
     - [x] xoshiro needs a wrapper (upstream state is file-scope statics, unusable for the
           matrix or for one generator per thread) — pinned to the vendored C by a
           side-by-side test rather than trusted
-  - [ ] Report GB/s **and** cycles/byte
+  - [x] Report GB/s **and** cycles/byte — every row reports both through `report_metrics`
+  - [ ] Run the matrix on frequency-pinned hardware and write it up. The laptop run that
+        validated the harness sits at 4-10% CV against this project's sub-1% bar, so it is a
+        smoke test rather than a result. It does put xoshiro256++ at roughly 2x the AVX2
+        kernel with PCG64 level with it, which is the comparison the write-up has to address
+        rather than omit
 - [ ] **Scaling** — `benchmarks/bench_scaling.cpp` at 1/2/4/8/16/32 threads
   - [ ] Confirm linear scaling; investigate any knee (memory bandwidth vs false sharing)
   - [ ] OpenMP variant alongside the `std::thread` one

--- a/benchmarks/bench_engines.cpp
+++ b/benchmarks/bench_engines.cpp
@@ -7,9 +7,11 @@
 // fallback is a serialized RDTSC measurement. On Linux ARM, perf_event_open
 // reads the hardware CPU-cycle counter directly.
 //
-// TODO(phase-4): add xoshiro256++ and PCG64 to complete the matrix. Both are
-// small enough to vendor into benchmarks/third_party/ rather than take as
-// dependencies.
+// Every row generates the same number of *bytes*, not the same number of
+// calls. xoshiro256++ and PCG64 return 64 bits per call and the rest return
+// 32, so a per-call loop would hand the 64-bit generators twice the output
+// for the same iteration count and flatter their cycles/byte by 2x. Equal
+// bytes is what makes the column comparable at all.
 
 #include <benchmark/benchmark.h>
 
@@ -28,6 +30,9 @@
 
 #include "vphilox/vphilox.hpp"
 
+#include "third_party/pcg-cpp/pcg_random.hpp"
+#include "third_party/xoshiro256plusplus.hpp"
+
 #if defined(__x86_64__) || defined(_M_X64)
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -45,6 +50,12 @@ constexpr std::size_t kWords = 1u << 16;  // 256 KiB per iteration: fits L2,
                                           // so this measures the generator
                                           // rather than memory bandwidth.
 constexpr std::size_t kBytesPerIteration = kWords * sizeof(vphilox::u32);
+
+// The 64-bit generators fill the same 256 KiB in half as many calls.
+static_assert(kWords % 2 == 0, "kWords must halve exactly for the 64-bit rows");
+constexpr std::size_t kWords64 = kWords / 2;
+static_assert(kWords64 * sizeof(std::uint64_t) == kBytesPerIteration,
+              "every row in the matrix must generate the same number of bytes");
 
 class cycle_counter {
 public:
@@ -233,6 +244,48 @@ void BM_philox_scalar(benchmark::State& state) {
     report_metrics(state, cycles);
 }
 BENCHMARK(BM_philox_scalar);
+
+/// xoshiro256++ 1.0 -- the speed benchmark people cite when they argue a
+/// counter-based generator cannot compete. It is not counter-based: no
+/// O(1) seek, no reproducible stream from an arbitrary (key, counter), and
+/// no way to hand thread N its own substream without jump(). Losing to it on
+/// cycles/byte would be unsurprising; the point of the row is to quantify
+/// what those properties actually cost.
+void BM_xoshiro256pp(benchmark::State& state) {
+    vphilox_bench::xoshiro256plusplus g{0xDEADBEEFull};
+    std::vector<std::uint64_t> out(kWords64);
+    cycle_counter cycles;
+
+    for (auto _ : state) {
+        cycles.start();
+        for (std::size_t i = 0; i < kWords64; ++i) out[i] = g();
+        benchmark::DoNotOptimize(out.data());
+        benchmark::ClobberMemory();
+        cycles.stop();
+    }
+    report_metrics(state, cycles);
+}
+BENCHMARK(BM_xoshiro256pp);
+
+/// PCG64 (setseq_xsl_rr_128_64). The closest thing in the matrix to vphilox's
+/// own design goals -- statistically strong, seekable, multiple streams -- so
+/// this is the row that measures the SIMD win rather than a difference in
+/// what the generator promises.
+void BM_pcg64(benchmark::State& state) {
+    pcg64 g{0xDEADBEEFull};
+    std::vector<std::uint64_t> out(kWords64);
+    cycle_counter cycles;
+
+    for (auto _ : state) {
+        cycles.start();
+        for (std::size_t i = 0; i < kWords64; ++i) out[i] = g();
+        benchmark::DoNotOptimize(out.data());
+        benchmark::ClobberMemory();
+        cycles.stop();
+    }
+    report_metrics(state, cycles);
+}
+BENCHMARK(BM_pcg64);
 
 }  // namespace
 


### PR DESCRIPTION
Closes the follow-through on the vendoring from c5b8e15: the generators were in the tree and pinned by tests, but nothing measured them.

Every row generates the same 256 KiB rather than the same number of calls. xoshiro256++ and PCG64 return 64 bits per call where the rest return 32, so a shared per-call loop would hand them twice the output for the same iteration count and halve their reported cycles/byte. Equal bytes is what makes the column comparable at all, and a static_assert holds the two word counts to the same byte total so a later edit to kWords cannot silently break it.

Both new rows report GB/s and cycles/byte through the existing report_metrics, which was the remaining piece of #49.

No measurement is recorded with this. The laptop run that exercised the harness sits at 4-10% CV against this project's sub-1% bar, so it is a smoke test rather than a result, and the write-up needs a frequency-pinned host. It is worth flagging what that run pointed at: xoshiro256++ came in around 2x the AVX2 kernel and PCG64 roughly level with it. If that holds up on quiet hardware, it is the comparison the paper has to meet head on -- vphilox's case is the counter-based properties xoshiro cannot offer at all (O(1) seek, a reproducible stream from any (key, counter), independent substreams without jump()), not raw single-threaded throughput.