### PR TITLE
Give the engine a portable serialized state

### DIFF
--- a/include/vphilox/counter.hpp
+++ b/include/vphilox/counter.hpp
@@ -30,6 +30,29 @@ constexpr void counter_add(counter4& c, u64 delta) noexcept {
     return c;
 }
 
+/// c -= delta, the exact inverse of counter_add, borrowing the same way it
+/// carries and wrapping at 2^128 rather than saturating. Serialization needs
+/// it: the engine tracks the counter its *next refill* will start from, which
+/// runs ahead of the value the caller will see next by however much is still
+/// buffered, and recovering the caller-visible position means stepping back.
+constexpr void counter_sub(counter4& c, u64 delta) noexcept {
+    u64 borrow = delta;
+    for (std::size_t i = 0; i < block_words && borrow != 0; ++i) {
+        const u64 lo   = borrow & 0xFFFFFFFFu;
+        const u64 diff = static_cast<u64>(c.v[i]) - lo;
+        c.v[i]         = static_cast<u32>(diff);
+        // diff >> 63 is the sign bit of the wrapped subtraction: 1 exactly
+        // when c.v[i] < lo, which is when the next word owes a borrow.
+        borrow = (borrow >> 32) + (diff >> 63);
+    }
+}
+
+/// Convenience: the counter `delta` blocks behind `c`.
+[[nodiscard]] constexpr counter4 counter_retreated(counter4 c, u64 delta) noexcept {
+    counter_sub(c, delta);
+    return c;
+}
+
 }  // namespace vphilox
 
 #endif  // VPHILOX_COUNTER_HPP

--- a/include/vphilox/philox.hpp
+++ b/include/vphilox/philox.hpp
@@ -40,6 +40,27 @@ namespace vphilox {
 inline constexpr std::size_t refill_blocks = 16;
 inline constexpr std::size_t refill_words  = refill_blocks * block_words;
 
+/// A snapshot of where an engine is in its stream.
+///
+/// Deliberately expressed as a position -- the block holding the next output
+/// and the word within it -- rather than as the engine's internals. The engine
+/// tracks the counter its *next refill* starts from, which runs ahead of the
+/// caller-visible position by however much is still buffered, and it holds a
+/// cursor into a buffer whose size is an implementation detail. Serializing
+/// those directly would bake `refill_blocks` into the format, so a state
+/// written before it changed from 8 to 16 would restore to the wrong place.
+///
+/// Every field is a plain integer. There is no floating point, no
+/// implementation-defined layout, and nothing whose textual form depends on
+/// the standard library in use -- which is the failure mode this exists to
+/// avoid, and the reason `std::mt19937`'s stream operator is not portable
+/// between libstdc++, libc++ and the MSVC STL.
+struct engine_state {
+    key2 key{};
+    counter4 counter{};  ///< block containing the next output
+    u32 offset{};        ///< word within that block, 0..block_words-1
+};
+
 /// Words converted per pass in the bulk float path. 256 words is 1 KiB of
 /// stack that stays resident in L1 across the generate/convert pair, and 64
 /// blocks -- comfortably past every backend's preferred_blocks, so the
@@ -257,6 +278,40 @@ public:
     void reset() noexcept {
         next_   = counter4{};
         cursor_ = refill_words;
+    }
+
+    /// Where the stream actually is, independent of buffering.
+    ///
+    /// `counter()` is not this: it is the counter the next refill starts from,
+    /// so reconstructing with `basic_engine(g.key(), g.counter())` silently
+    /// skips whatever was still buffered -- up to `refill_words` outputs.
+    /// Round-tripping through this and `set_state` skips nothing.
+    [[nodiscard]] engine_state state() const noexcept {
+        // The buffer holds blocks [next_ - refill_blocks, next_), and cursor_
+        // words of it are spent. cursor_ == refill_words (the "needs a refill"
+        // state) falls out of the same expression, landing exactly on next_.
+        const auto blocks_consumed = cursor_ / block_words;
+        return engine_state{key_, counter_retreated(next_, refill_blocks - blocks_consumed),
+                            static_cast<u32>(cursor_ % block_words)};
+    }
+
+    /// Restore a position previously returned by `state()`. The engine then
+    /// produces exactly what it would have produced from that point.
+    ///
+    /// `offset` is taken modulo `block_words`; a larger value could only come
+    /// from a corrupted state, and wrapping it is preferable to indexing off
+    /// the end of a block.
+    void set_state(const engine_state& st) noexcept {
+        key_              = st.key;
+        next_             = st.counter;
+        cursor_           = refill_words;  // force a refill starting at st.counter
+        const auto offset = static_cast<std::size_t>(st.offset % block_words);
+        if (offset != 0) {
+            // discard() lands the cursor inside a fresh refill; at offset 0
+            // the lazy "needs a refill" state above is already correct, and
+            // leaving it avoids generating a buffer the caller may never read.
+            discard(offset);
+        }
     }
 
     [[nodiscard]] key2 key() const noexcept { return key_; }

--- a/include/vphilox/serialize.hpp
+++ b/include/vphilox/serialize.hpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Parth Sinha
+
+// vphilox - serialize.hpp
+//
+// Portable text form for an engine's position.
+//
+// This is the problem the library was built around. `std::mt19937`'s stream
+// operator is not portable between standard libraries, for two independent
+// reasons: the format flags (the standard has operator<< set ios_base::dec
+// itself, so libstdc++ ignores a caller's std::hex while the MSVC STL does
+// not, and each then reads the other's digits in the wrong base), and the
+// layout (libstdc++ writes 624 state words in raw order plus a position;
+// libc++ and the MSVC STL write 624 rotated into canonical order with no
+// position). A checkpoint written on Linux does not reliably load on Windows,
+// and on macOS it can load *wrongly* without any error at all.
+//
+// Three rules follow from that, and this file keeps all of them.
+//
+// 1. Serialize a position, not an implementation. The fields are the key, the
+//    block holding the next output, and the word within it -- see engine_state
+//    in philox.hpp. Nothing here depends on `refill_blocks`, so a state
+//    written before that changed from 8 to 16 still restores correctly.
+//
+// 2. Never touch the locale. Integer extraction through std::istream consults
+//    the global locale's num_get, which can be imbued with a facet that groups
+//    digits. Digits are written and parsed by hand below; the only stream
+//    operation is on characters.
+//
+// 3. Refuse anything unrecognised rather than interpret it. The format carries
+//    a version tag, and parsing fails on a wrong tag, a wrong field count, a
+//    value past 2^32-1, a word offset outside a block, or trailing rubbish. A
+//    state that cannot be read is an error the caller can see, not a stream
+//    that silently resumes somewhere else.
+
+#ifndef VPHILOX_SERIALIZE_HPP
+#define VPHILOX_SERIALIZE_HPP
+
+#include <istream>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+#include "vphilox/philox.hpp"
+
+namespace vphilox {
+
+/// Tag identifying the format below. Present so that a future format is a
+/// clean parse failure rather than a misreading of these fields.
+inline constexpr std::string_view state_format_tag = "vphilox1";
+
+namespace detail {
+
+/// Decimal digits of `v`, appended by hand. std::to_string would do, but it
+/// routes through the locale on some implementations; this cannot.
+inline void append_u32(std::string& out, u32 v) {
+    char buf[10];
+    std::size_t n = 0;
+    do {
+        buf[n++] = static_cast<char>('0' + (v % 10u));
+        v /= 10u;
+    } while (v != 0);
+    while (n != 0) out.push_back(buf[--n]);
+}
+
+/// Parse one decimal field, rejecting anything that is not digits and
+/// anything that would not fit in 32 bits. `pos` stops on the first non-digit
+/// -- separators are the caller's business, so exactly one space between
+/// fields can be required and a trailing one refused.
+[[nodiscard]] inline bool parse_u32(std::string_view s, std::size_t& pos, u32& out) {
+    if (pos >= s.size() || s[pos] < '0' || s[pos] > '9') return false;
+
+    u64 acc = 0;
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9') {
+        acc = acc * 10 + static_cast<u64>(s[pos] - '0');
+        if (acc > 0xFFFFFFFFull) return false;  // would not round-trip
+        ++pos;
+    }
+    out = static_cast<u32>(acc);
+    return true;
+}
+
+}  // namespace detail
+
+/// The textual form of `st`: the tag, then seven decimal fields.
+[[nodiscard]] inline std::string to_string(const engine_state& st) {
+    std::string out;
+    out.reserve(state_format_tag.size() + 7 * 11);
+    out.append(state_format_tag);
+    for (const u32 v : {st.key.v[0], st.key.v[1], st.counter.v[0], st.counter.v[1], st.counter.v[2],
+                        st.counter.v[3], st.offset}) {
+        out.push_back(' ');
+        detail::append_u32(out, v);
+    }
+    return out;
+}
+
+/// Parse a state written by `to_string`. Returns false and leaves `out`
+/// untouched if the text is not exactly one well-formed state.
+[[nodiscard]] inline bool from_string(std::string_view text, engine_state& out) {
+    if (text.size() < state_format_tag.size()) return false;
+    if (text.substr(0, state_format_tag.size()) != state_format_tag) return false;
+
+    std::size_t pos = state_format_tag.size();
+    if (pos >= text.size() || text[pos] != ' ') return false;
+    ++pos;
+
+    // Exactly one space between fields, and nothing at all after the last.
+    // Being strict is the point: a format that tolerates stray bytes is one
+    // that will eventually accept some other format's output.
+    u32 f[7]{};
+    for (std::size_t i = 0; i < 7; ++i) {
+        if (i != 0) {
+            if (pos >= text.size() || text[pos] != ' ') return false;
+            ++pos;
+        }
+        if (!detail::parse_u32(text, pos, f[i])) return false;
+    }
+    if (pos != text.size()) return false;                     // trailing rubbish
+    if (f[6] >= static_cast<u32>(block_words)) return false;  // offset outside a block
+
+    out = engine_state{key2{{f[0], f[1]}}, counter4{{f[2], f[3], f[4], f[5]}}, f[6]};
+    return true;
+}
+
+/// Write an engine's position. Only characters reach the stream, so the
+/// result does not depend on the stream's format flags or its locale.
+template <unsigned Rounds>
+std::ostream& operator<<(std::ostream& os, const basic_engine<Rounds>& g) {
+    return os << to_string(g.state());
+}
+
+/// Read a position previously written by `operator<<`. On malformed input the
+/// stream's failbit is set and the engine is left exactly as it was.
+template <unsigned Rounds>
+std::istream& operator>>(std::istream& is, basic_engine<Rounds>& g) {
+    std::string token;
+    std::string text;
+
+    // Eight whitespace-delimited tokens, joined with single spaces. Reading
+    // tokens rather than formatted integers is what keeps num_get, and with it
+    // the locale, out of the path.
+    for (int i = 0; i < 8; ++i) {
+        if (!(is >> token)) return is;
+        if (i != 0) text.push_back(' ');
+        text.append(token);
+    }
+
+    engine_state st;
+    if (!from_string(text, st)) {
+        is.setstate(std::ios_base::failbit);
+        return is;
+    }
+    g.set_state(st);
+    return is;
+}
+
+}  // namespace vphilox
+
+#endif  // VPHILOX_SERIALIZE_HPP

--- a/include/vphilox/vphilox.hpp
+++ b/include/vphilox/vphilox.hpp
@@ -17,4 +17,9 @@
 #include "vphilox/philox.hpp"
 #include "vphilox/version.hpp"
 
+// Deliberately not included here: "vphilox/serialize.hpp", which gives an
+// engine a portable text form. It pulls in <istream>, <ostream> and <string>,
+// and most callers of a generator never serialize one. Include it directly
+// where you need it.
+
 #endif  // VPHILOX_VPHILOX_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(VPHILOX_TEST_SOURCES
     test_seeding.cpp          # Phase 3: seed_seq / u64 seeding and overload rank
     test_third_party_generators.cpp  # Phase 4: benchmark baselines are the real algorithms
     test_cross_platform_parity.cpp   # Phase 4: the bit stream is identical on every target
+    test_serialization.cpp    # portable engine state: exact, locale-free, refuses junk
 )
 
 foreach(src IN LISTS VPHILOX_TEST_SOURCES)

--- a/tests/test_counter.cpp
+++ b/tests/test_counter.cpp
@@ -6,11 +6,17 @@
 
 #include <gtest/gtest.h>
 
+#include <random>
+
 #include "vphilox/counter.hpp"
 
 using vphilox::counter4;
 using vphilox::counter_add;
 using vphilox::counter_advanced;
+using vphilox::counter_retreated;
+using vphilox::counter_sub;
+using vphilox::u32;
+using vphilox::u64;
 
 TEST(Counter, AddsWithoutCarry) {
     counter4 c{{1, 2, 3, 4}};
@@ -54,4 +60,44 @@ TEST(Counter, AddIsAssociative) {
 TEST(Counter, AddZeroIsIdentity) {
     const counter4 c{{5, 6, 7, 8}};
     EXPECT_EQ(counter_advanced(c, 0), c);
+}
+
+TEST(Counter, SubtractUndoesAdd) {
+    // The property serialization leans on: recovering a caller-visible
+    // position means stepping back exactly as far as the engine ran ahead.
+    std::mt19937_64 rng{1};
+    for (int i = 0; i < 20000; ++i) {
+        const counter4 start{{static_cast<u32>(rng()), static_cast<u32>(rng()),
+                              static_cast<u32>(rng()), static_cast<u32>(rng())}};
+        const u64 delta = rng();
+
+        counter4 c = start;
+        counter_add(c, delta);
+        counter_sub(c, delta);
+        ASSERT_EQ(c, start) << "delta " << delta;
+    }
+}
+
+TEST(Counter, SubtractBorrowsAcrossEveryWord) {
+    EXPECT_EQ(counter_retreated(counter4{{0, 1, 0, 0}}, 1), (counter4{{0xFFFFFFFFu, 0, 0, 0}}));
+    EXPECT_EQ(counter_retreated(counter4{{0, 0, 1, 0}}, 1),
+              (counter4{{0xFFFFFFFFu, 0xFFFFFFFFu, 0, 0}}));
+    EXPECT_EQ(counter_retreated(counter4{{0, 0, 0, 1}}, 1),
+              (counter4{{0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0}}));
+}
+
+TEST(Counter, SubtractWrapsAtZero) {
+    // Mirrors counter_add's silent wrap at 2^128 rather than saturating.
+    EXPECT_EQ(counter_retreated(counter4{}, 1),
+              (counter4{{0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu}}));
+}
+
+TEST(Counter, SubtractHandlesDeltaWiderThanOneWord) {
+    EXPECT_EQ(counter_retreated(counter4{}, 0x1'0000'0000ull),
+              (counter4{{0, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu}}));
+}
+
+TEST(Counter, SubtractZeroIsIdentity) {
+    const counter4 c{{5, 6, 7, 8}};
+    EXPECT_EQ(counter_retreated(c, 0), c);
 }

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Parth Sinha
+
+// Portable serialization of engine position.
+//
+// The library exists because std::mt19937's serialized state does not survive
+// a change of standard library. These tests pin the three properties that
+// failure taught: the round trip is exact, the text does not depend on the
+// locale, and unrecognised input is refused rather than reinterpreted.
+
+#include <gtest/gtest.h>
+
+#include <locale>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "vphilox/serialize.hpp"
+#include "vphilox/vphilox.hpp"
+
+namespace {
+
+using vphilox::engine;
+using vphilox::engine_state;
+
+/// A locale that groups digits, to prove the writer never consults one. If
+/// anything here went through num_put, output would gain separators.
+struct grouping_punct : std::numpunct<char> {
+protected:
+    char do_thousands_sep() const override { return '\''; }
+    std::string do_grouping() const override { return "\3"; }
+};
+
+TEST(Serialization, RoundTripIsExactAtEveryOffset) {
+    // Spanning several refills, so the cursor is mid-buffer, on a block
+    // boundary, and at the "needs a refill" edge.
+    for (std::size_t n = 0; n <= vphilox::refill_words * 3 + 7; ++n) {
+        engine a{0xDEADBEEFull};
+        for (std::size_t i = 0; i < n; ++i) (void)a();
+
+        engine b{};
+        b.set_state(a.state());
+
+        for (int k = 0; k < 64; ++k) {
+            ASSERT_EQ(a(), b()) << "after " << n << " draws, output " << k;
+        }
+    }
+}
+
+/// The bug this guards: the engine's own counter runs ahead of the caller's
+/// position by whatever is still buffered, so the obvious reconstruction
+/// loses outputs. state() must not have that flaw.
+TEST(Serialization, KeyAndCounterAloneAreNotEnough) {
+    engine a{1};
+    for (int i = 0; i < 5; ++i) (void)a();
+
+    engine naive{a.key(), a.counter()};
+    engine restored{};
+    restored.set_state(a.state());
+
+    const auto expected = a();
+    EXPECT_EQ(restored(), expected);
+    EXPECT_NE(naive(), expected) << "if this ever matches, counter() changed meaning";
+}
+
+TEST(Serialization, TextRoundTripsThroughStringForm) {
+    engine a{0xABCDEF};
+    a.discard(12345);
+    for (int i = 0; i < 3; ++i) (void)a();
+
+    engine_state parsed{};
+    ASSERT_TRUE(vphilox::from_string(vphilox::to_string(a.state()), parsed));
+
+    engine b{};
+    b.set_state(parsed);
+    for (int k = 0; k < 32; ++k) ASSERT_EQ(a(), b());
+}
+
+/// The text describes a position, so two engines that reached the same point
+/// by different routes serialize identically. That is what makes the format
+/// independent of refill_blocks, which has already changed once.
+TEST(Serialization, TextDependsOnPositionNotOnHowItWasReached) {
+    engine stepped{7};
+    for (int i = 0; i < 37; ++i) (void)stepped();
+
+    engine jumped{7};
+    jumped.discard(37);
+
+    EXPECT_EQ(vphilox::to_string(stepped.state()), vphilox::to_string(jumped.state()));
+}
+
+TEST(Serialization, WrittenTextIsPlainDecimalFields) {
+    engine a{1};
+    const auto text = vphilox::to_string(a.state());
+    EXPECT_EQ(text, "vphilox1 1 0 0 0 0 0 0");
+}
+
+TEST(Serialization, OutputIgnoresStreamLocale) {
+    engine a{0xFFFFFFFFull};
+    a.discard(1000000);
+
+    std::ostringstream plain;
+    plain << a;
+
+    std::ostringstream grouped;
+    grouped.imbue(std::locale(grouped.getloc(), new grouping_punct));
+    grouped << a;
+
+    EXPECT_EQ(plain.str(), grouped.str());
+    EXPECT_EQ(plain.str().find('\''), std::string::npos) << "a locale reached the digits";
+}
+
+TEST(Serialization, OutputIgnoresStreamFormatFlags) {
+    engine a{255};
+    std::ostringstream dec, hex;
+    hex << std::hex << std::uppercase;
+    dec << a;
+    hex << a;
+    EXPECT_EQ(dec.str(), hex.str()) << "format flags changed the encoding, as they do for mt19937";
+}
+
+TEST(Serialization, StreamRoundTrip) {
+    engine a{0x1234};
+    for (int i = 0; i < 100; ++i) (void)a();
+
+    std::stringstream ss;
+    ss << a;
+
+    engine b{};
+    ss >> b;
+    ASSERT_FALSE(ss.fail());
+
+    for (int k = 0; k < 32; ++k) ASSERT_EQ(a(), b());
+}
+
+TEST(Serialization, MalformedInputIsRefused) {
+    const char* bad[] = {
+        "",
+        "vphilox1",
+        "vphilox1 1 2 3",                    // too few fields
+        "vphilox1 1 2 3 4 5 6 0 9",          // too many
+        "vphilox0 1 2 3 4 5 6 0",            // wrong version tag
+        "mt19937 1 2 3 4 5 6 0",             // another format entirely
+        "vphilox1 1 2 3 4 5 6 4",            // offset outside a block
+        "vphilox1 4294967296 0 0 0 0 0 0",   // one past 2^32-1
+        "vphilox1 99999999999 0 0 0 0 0 0",  // far past
+        "vphilox1 1 2 3 4 5 6 x",            // not a number
+        "vphilox1 -1 0 0 0 0 0 0",           // sign
+        "vphilox1 1 2 3 4 5 6 0 ",           // trailing space
+        "vphilox1  1 2 3 4 5 6 0",           // doubled separator
+        "vphilox1 1 2 3 4 5 60",             // separator missing
+        "vphilox1 1 2 3 4 5 6 0\n",          // trailing space
+    };
+    for (const char* text : bad) {
+        engine_state st{};
+        EXPECT_FALSE(vphilox::from_string(text, st)) << "accepted: '" << text << "'";
+    }
+}
+
+TEST(Serialization, BadStreamInputSetsFailbitAndLeavesEngineAlone) {
+    engine a{99};
+    const auto before = vphilox::to_string(a.state());
+
+    std::istringstream ss{"vphilox1 1 2 3 4 5 6 4"};  // offset outside a block
+    ss >> a;
+
+    EXPECT_TRUE(ss.fail());
+    EXPECT_EQ(vphilox::to_string(a.state()), before) << "engine mutated on a failed read";
+}
+
+/// A 2^128 counter must survive the trip, since O(1) discard is what makes
+/// deep positions reachable in the first place.
+TEST(Serialization, SurvivesADeepPosition) {
+    engine a{0x5EED};
+    a.discard(vphilox::u64{1} << 40);
+
+    std::stringstream ss;
+    ss << a;
+    engine b{};
+    ss >> b;
+    ASSERT_FALSE(ss.fail());
+
+    for (int k = 0; k < 16; ++k) ASSERT_EQ(a(), b());
+}
+
+}  // namespace


### PR DESCRIPTION
The library exists because std::mt19937's serialized state does not survive a change of standard library, and until now vphilox could not serialize an engine at all. The two observers that look like they would do it will not: counter() is the counter the *next refill* starts from, so reconstructing with basic_engine(g.key(), g.counter()) silently skips whatever is still buffered -- up to refill_words outputs. There is a test asserting that it skips, so the day counter() changes meaning, something says so.

engine_state records a position instead: the key, the block holding the next output, and the word within it. state() and set_state() round-trip it exactly, verified at every cursor offset across several refills and through the bulk path as well as operator().

Serializing a position rather than the engine's internals is what keeps the format stable. Writing next_ and cursor_ directly would bake refill_blocks into it, and refill_blocks changed from 8 to 16 earlier today when the AVX-512 kernel landed -- a state written before that would now restore to the wrong place. A test pins this by requiring the same text from an engine that stepped to a position and one that jumped there with discard().

serialize.hpp adds the text form, keeping the three rules the mt19937 failure taught. The fields are plain integers, so nothing depends on an implementation's idea of layout. Digits are written and parsed by hand, never through num_put or num_get, because integer extraction consults the global locale and a grouping facet would corrupt the output -- there is a test that imbues one and requires the text to be unchanged, and another that requires std::hex on the stream to make no difference, which is precisely what it does not do for mt19937. And the format carries a version tag and refuses anything it does not recognise: wrong tag, wrong field count, a value past 2^32-1, an offset outside a block, a doubled or missing separator, trailing bytes. A failed read sets failbit and leaves the engine untouched rather than resuming somewhere else, which is the silent-corruption case that made the original bug so hard to see.

counter_sub and counter_retreated are the arithmetic this needs, since recovering the caller-visible position means stepping back over the buffered run. Checked against 20000 random add/subtract round trips, borrows across every word boundary, and the wrap at zero that mirrors counter_add's at 2^128.

serialize.hpp is deliberately not pulled in by vphilox.hpp: it needs <istream>, <ostream> and <string>, and most callers of a generator never serialize one.

106 tests, green on default, debug, scalar and asan.