### PR TITLE
Measure instruction supply with per-worker perf counters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,21 @@ refuses runs that are not worth writing up:
 ```bash
 scripts/benchmarks/run_matrix.sh --tag <machine> --cpu <isolated-cpu>
 scripts/benchmarks/run_matrix.sh --tag <machine> --bench scaling   # unpinned; needs every core
+scripts/benchmarks/run_matrix.sh --tag <machine> --bench scaling --perf-counters  # i-cache study
 ```
+
+`--perf-counters` adds per-worker retired-instruction and L1 i-cache-miss
+counters (#53) and writes `<tag>-icache.json` rather than `<tag>-scaling.json`.
+Keep the two apart: the extra ioctls land in wall time, so **only `icache_mpki`
+and `instructions_per_byte` are quotable from an i-cache run** — its
+`bytes_per_second` is not comparable with the published scaling curve. The
+counters are per-worker rather than Google Benchmark's
+`--benchmark_perf_counters` because those start and stop on the thread running
+the benchmark loop, which here is the dispatcher: it blocks on a condition
+variable while the workers do every instruction. `instructions_per_byte` is
+the built-in check — it is a property of the kernel, so it must not move with
+thread count, and a run where it does has counters attached to the wrong
+threads.
 
 It writes `results/<tag>-{matrix,scaling}.json` plus a matching
 `-environment.txt`, and exits non-zero if the cycle counter did not report or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,9 @@ particular) is a comparison worth *reporting* honestly, not a target to chase.
 Derived from `docs/VPhilox Development Phases.md` and
 `docs/Vector Philox Development Strategy.md`.
 
-**Status:** Phases 0-3 complete; Phase 4 complete except libpfm.
+**Status:** Phases 0-3 complete; Phase 4 complete except two measurements that
+need hardware — the instruction-cache study (harness ready, wants the pinned
+16-core host) and a cuRAND/GPU parity reference.
 Current version
 `2026.08.0` (see [VERSIONING.md](VERSIONING.md)).
 
@@ -435,7 +437,35 @@ and whose state can be written on one platform and read on another.
         identity check, because a `perf_event_open` counter measures the thread
         that opened it and OpenMP does not promise a stable thread-number-to-thread
         mapping across regions. Both report a skipped row rather than a number
-  - [ ] Instruction-cache miss rates via libpfm
+  - [~] Instruction-cache miss rates — harness done, measurement pending a host
+        worth quoting. `--perf-counters` on a scaling run gives per-worker
+        `icache_mpki` and `instructions_per_byte`, written to `<tag>-icache.json`
+        so an instruction-supply study never overwrites the throughput curve it
+        explains.
+    - [x] **Not libpfm, and not `--benchmark_perf_counters`.** Both were the
+          original plan and both are wrong here. Google Benchmark's counters
+          start and stop on the thread running the benchmark loop, which in this
+          pool-driven benchmark is the dispatcher — it blocks on a condition
+          variable while the workers do every instruction, so the numbers would
+          have been a near-empty thread on the `std::thread` path and one
+          worker's share on the OpenMP one, both looking like an aggregate. Per-
+          worker counters, summed as `cycle_counter` already is, are the only
+          shape that answers the question. That also removes the dependency:
+          retired instructions and L1 i-cache read misses are both generic
+          `perf_event_open` events, so libpfm is not needed at all
+    - [x] A denied PMU drops the counter rather than reporting a zero, and
+          `run_matrix.sh` exits non-zero if an `--perf-counters` run produced no
+          `icache_mpki`. An MPKI of 0.00 is a plausible answer to this question,
+          so it must never be what a missing PMU produces
+    - [x] `instructions_per_byte` doubles as the self-check: it is a property of
+          the kernel, so it must not move with thread count. Measured invariant
+          to six digits from 1 to 8 threads, and 0.00% CV across repetitions
+    - [ ] The measurement itself, on the pinned 16-core host from #51. The
+          question is narrow: #51 concluded the hyperthread knee is
+          execution-port contention, and the standing alternative is that two
+          workers on one core thrash a shared instruction cache, since these
+          kernels are large unrolled bodies. MPKI flat across the co-location
+          boundary excludes it; MPKI that climbs with it does not
 - [~] **Cross-platform bit parity** — same key and counter produce identical output on x86-64,
       aarch64, and (if reachable) a cuRAND/GPU reference. This is the reproducibility claim;
       it needs a test, not an assertion.

--- a/benchmarks/bench_cycles.hpp
+++ b/benchmarks/bench_cycles.hpp
@@ -8,6 +8,10 @@
 // *calling* thread, so a multi-threaded benchmark must construct a counter
 // inside each worker rather than sharing one -- see bench_scaling.cpp, where
 // the per-thread totals are summed to give aggregate cycles per byte.
+//
+// `perf_counter` below applies the same rule to retired instructions and L1
+// instruction-cache misses (#53), which is what the instruction-supply half of
+// the scaling study needs.
 
 #ifndef VPHILOX_BENCH_CYCLES_HPP
 #define VPHILOX_BENCH_CYCLES_HPP
@@ -25,18 +29,24 @@
 #define VPHILOX_BENCH_HAS_RDTSC 0
 #endif
 
-#if defined(__linux__) && !VPHILOX_BENCH_HAS_RDTSC
+// perf_event_open backs the cycle counter on ARM and the instruction/i-cache
+// counters everywhere, so the headers are needed on any Linux, not just the
+// non-RDTSC targets.
+#if defined(__linux__)
 #include <linux/perf_event.h>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#define VPHILOX_BENCH_HAS_PERF 1
+#else
+#define VPHILOX_BENCH_HAS_PERF 0
 #endif
 
 namespace vphilox_bench {
 
 class cycle_counter {
 public:
-#if defined(__linux__) && !VPHILOX_BENCH_HAS_RDTSC
+#if VPHILOX_BENCH_HAS_PERF && !VPHILOX_BENCH_HAS_RDTSC
     cycle_counter() noexcept {
         perf_event_attr attr{};
         attr.type           = PERF_TYPE_HARDWARE;
@@ -104,7 +114,95 @@ public:
 private:
     std::uint64_t start_{};
     std::uint64_t total_{};
-#if defined(__linux__) && !VPHILOX_BENCH_HAS_RDTSC
+#if VPHILOX_BENCH_HAS_PERF && !VPHILOX_BENCH_HAS_RDTSC
+    int fd_{-1};
+#endif
+};
+
+/// One hardware perf event, opened on the calling thread.
+///
+/// This exists rather than Google Benchmark's `--benchmark_perf_counters` for
+/// a specific reason. Those counters start and stop on the thread running the
+/// benchmark loop (`benchmark.cc`, in `State::ResumeTiming`), and in a
+/// pool-driven benchmark that thread is the dispatcher: on the std::thread
+/// path it blocks on a condition variable while the workers do every
+/// instruction, so the counters would report a near-empty thread; on the
+/// OpenMP path the caller is the team master, so they would report one
+/// worker's share and read like an aggregate. Per-worker counters, summed the
+/// way `cycle_counter` already is, are the only shape that answers the
+/// question being asked.
+///
+/// libpfm is deliberately not involved. The two events wanted here --
+/// retired instructions and L1 instruction-cache read misses -- are both
+/// generic `perf_event_open` events, so this needs no dependency beyond the
+/// kernel headers already used for the ARM cycle counter.
+class perf_counter {
+public:
+    enum class kind {
+        instructions,   ///< PERF_COUNT_HW_INSTRUCTIONS, the MPKI denominator
+        icache_misses,  ///< L1 instruction cache, read, miss
+    };
+
+    perf_counter()                               = default;
+    perf_counter(const perf_counter&)            = delete;
+    perf_counter& operator=(const perf_counter&) = delete;
+
+#if VPHILOX_BENCH_HAS_PERF
+    ~perf_counter() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    /// Returns false if the kernel refused the event, which is normal rather
+    /// than exceptional: a VM may expose no PMU at all, and
+    /// perf_event_paranoid can forbid it. The caller reports nothing in that
+    /// case instead of reporting a zero.
+    bool open(kind k) noexcept {
+        perf_event_attr attr{};
+        attr.size           = static_cast<decltype(attr.size)>(sizeof(attr));
+        attr.disabled       = 1;
+        attr.exclude_kernel = 1;
+        attr.exclude_hv     = 1;
+        if (k == kind::instructions) {
+            attr.type   = PERF_TYPE_HARDWARE;
+            attr.config = PERF_COUNT_HW_INSTRUCTIONS;
+        } else {
+            attr.type   = PERF_TYPE_HW_CACHE;
+            attr.config = PERF_COUNT_HW_CACHE_L1I | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+                          (PERF_COUNT_HW_CACHE_RESULT_MISS << 16);
+        }
+        fd_ = static_cast<int>(syscall(SYS_perf_event_open, &attr, 0, -1, -1, 0));
+        return fd_ >= 0;
+    }
+
+    void start() noexcept {
+        if (fd_ < 0) return;
+        ioctl(fd_, PERF_EVENT_IOC_RESET, 0);
+        ioctl(fd_, PERF_EVENT_IOC_ENABLE, 0);
+    }
+
+    void stop() noexcept {
+        if (fd_ < 0) return;
+        ioctl(fd_, PERF_EVENT_IOC_DISABLE, 0);
+        std::uint64_t measured{};
+        if (read(fd_, &measured, sizeof(measured)) == static_cast<ssize_t>(sizeof(measured))) {
+            total_ += measured;
+        }
+    }
+
+    [[nodiscard]] bool available() const noexcept { return fd_ >= 0; }
+#else
+    bool open(kind) noexcept { return false; }
+    void start() noexcept {}
+    void stop() noexcept {}
+    [[nodiscard]] bool available() const noexcept { return false; }
+#endif
+
+    /// Unrounded total, for summing across threads before dividing.
+    [[nodiscard]] std::uint64_t raw() const noexcept { return total_; }
+
+private:
+    std::uint64_t total_{};
+#if VPHILOX_BENCH_HAS_PERF
     int fd_{-1};
 #endif
 };

--- a/benchmarks/bench_scaling.cpp
+++ b/benchmarks/bench_scaling.cpp
@@ -41,6 +41,19 @@
 // because the fixed spawn cost amortised better. With the pool, both columns
 // measure the same work.
 //
+// Instruction supply (#53) is measured on demand, not on every run. Set
+// VPHILOX_PERF_COUNTERS=1 and each worker also opens retired-instruction and
+// L1 i-cache-miss counters on itself, and the row gains `icache_mpki` and
+// `instructions_per_byte`. It is opt-in because the extra ioctl pair per
+// worker per iteration lands in wall time and so in `bytes_per_second`, and
+// the published scaling rows must not move because a diagnostic was added.
+//
+// The question it answers is narrow. #51 concluded the hyperthread knee is
+// execution-port contention; the standing alternative is that two workers on
+// one core thrash a shared instruction cache, since these kernels are large
+// unrolled bodies. MPKI flat across the co-location boundary excludes that,
+// and MPKI that climbs with it does not.
+//
 // One caveat remains. On x86 the counter is RDTSC, which counts reference
 // cycles rather than core cycles. Adding threads moves the turbo ceiling, so
 // on a machine without a pinned clock part of any movement in cycles/byte is
@@ -62,6 +75,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -81,6 +95,17 @@
 namespace {
 
 using vphilox_bench::cycle_counter;
+using vphilox_bench::perf_counter;
+
+/// Opt-in instruction-supply counters (#53). Read once: getenv in the worker
+/// path would be a shared-state read inside the measured region.
+bool perf_counters_wanted() {
+    static const bool wanted = [] {
+        const char* v = std::getenv("VPHILOX_PERF_COUNTERS");
+        return v != nullptr && v[0] != '\0' && v[0] != '0';
+    }();
+    return wanted;
+}
 
 /// A fixed set of workers that outlive the benchmark loop.
 ///
@@ -192,6 +217,11 @@ void run_scaling(benchmark::State& state) {
     std::vector<std::thread::id> owners(threads);
     std::atomic<bool> migrated{false};
 
+    // Instruction supply, same per-worker ownership rule, same lifetime.
+    const bool want_perf = perf_counters_wanted();
+    std::vector<std::unique_ptr<perf_counter>> instrs(threads);
+    std::vector<std::unique_ptr<perf_counter>> imisses(threads);
+
     const std::function<void(std::size_t)> job = [&](std::size_t t) {
         if (!counters[t]) {
             counters[t] = std::make_unique<cycle_counter>();
@@ -201,12 +231,23 @@ void run_scaling(benchmark::State& state) {
         }
         auto& cycles = *counters[t];
 
+        if (want_perf && !instrs[t]) {
+            instrs[t]  = std::make_unique<perf_counter>();
+            imisses[t] = std::make_unique<perf_counter>();
+            instrs[t]->open(perf_counter::kind::instructions);
+            imisses[t]->open(perf_counter::kind::icache_misses);
+        }
+
         const auto start = vphilox::counter_advanced(
             vphilox::counter4{}, static_cast<vphilox::u64>(t) * (words / vphilox::block_words));
 
         vphilox::engine g{key, start};
         auto& buf = *buffers[t];
 
+        if (want_perf) {
+            instrs[t]->start();
+            imisses[t]->start();
+        }
         cycles.start();
         if constexpr (Mode == fill_mode::bulk) {
             g.generate_n(buf.data(), words);
@@ -214,6 +255,10 @@ void run_scaling(benchmark::State& state) {
             for (std::size_t i = 0; i < words; ++i) buf[i] = g();
         }
         cycles.stop();
+        if (want_perf) {
+            imisses[t]->stop();
+            instrs[t]->stop();
+        }
 
         benchmark::DoNotOptimize(buf.data());
     };
@@ -276,6 +321,34 @@ void run_scaling(benchmark::State& state) {
         label += std::string{", cycle_source="} + counters.front()->source();
     }
     state.counters["kib_per_thread"] = static_cast<double>(words * sizeof(vphilox::u32)) / 1024.0;
+
+    if (want_perf) {
+        std::uint64_t total_instr = 0;
+        std::uint64_t total_imiss = 0;
+        bool all_available        = true;
+        for (std::size_t t = 0; t < threads; ++t) {
+            if (!instrs[t] || !instrs[t]->available() || !imisses[t]->available()) {
+                all_available = false;
+                break;
+            }
+            total_instr += instrs[t]->raw();
+            total_imiss += imisses[t]->raw();
+        }
+        // A denied event reports nothing rather than a zero: an MPKI of 0.00
+        // is the answer this study is looking for, so it must never be what a
+        // missing PMU produces. `perf_event_paranoid` and VMs without a vPMU
+        // both land here.
+        if (!all_available || total_instr == 0) {
+            state.SetLabel(label + ", perf_counters=unavailable");
+            return;
+        }
+        state.counters["icache_mpki"] =
+            static_cast<double>(total_imiss) * 1000.0 / static_cast<double>(total_instr);
+        state.counters["instructions_per_byte"] =
+            static_cast<double>(total_instr) / static_cast<double>(bytes);
+        label += ", perf_counters=on";
+    }
+
     state.SetLabel(label);
 }
 

--- a/scripts/benchmarks/run_matrix.sh
+++ b/scripts/benchmarks/run_matrix.sh
@@ -11,10 +11,19 @@
 #   scripts/benchmarks/run_matrix.sh --tag pi-arm --cpu 3
 #   scripts/benchmarks/run_matrix.sh --tag pi-arm --bench scaling
 #   scripts/benchmarks/run_matrix.sh --tag icelake --cpu 2 --repetitions 9
+#   scripts/benchmarks/run_matrix.sh --tag icelake --bench scaling --perf-counters
 #
 # --bench engines (default) runs the throughput matrix pinned to one CPU.
 # --bench scaling runs the thread-scaling curve, which needs every core, so it
 # is not pinned to a single CPU.
+#
+# --perf-counters adds per-worker instruction and L1 i-cache-miss counters to a
+# scaling run (#53) and writes to <tag>-icache.json instead, so an
+# instruction-supply study never overwrites the throughput curve it is
+# explaining. The extra ioctls land in wall time, which is why it is a separate
+# run rather than always on: `bytes_per_second` from a --perf-counters run is
+# not comparable with the published scaling numbers, and only `icache_mpki`
+# and `instructions_per_byte` should be quoted from it.
 #
 # The governor is forced to `performance` for the duration and restored on
 # exit, including on Ctrl-C. Results below this project's sub-1% cycles/byte
@@ -33,6 +42,7 @@ cpu=3
 repetitions=7
 min_time="1s"
 filter='.*'
+perf_counters=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -42,6 +52,7 @@ while [[ $# -gt 0 ]]; do
         --repetitions) repetitions="$2"; shift 2 ;;
         --min-time)    min_time="$2"; shift 2 ;;
         --filter)      filter="$2"; shift 2 ;;
+        --perf-counters) perf_counters=1; shift ;;
         *) echo "unknown option: $1" >&2; exit 2 ;;
     esac
 done
@@ -67,6 +78,18 @@ case "$bench" in
         ;;
     *) echo "unknown --bench: $bench (expected 'engines' or 'scaling')" >&2; exit 2 ;;
 esac
+
+if [[ "$perf_counters" == 1 ]]; then
+    if [[ "$bench" != "scaling" ]]; then
+        echo "--perf-counters applies to --bench scaling only" >&2
+        exit 2
+    fi
+    # A separate suffix, so the throughput curve and the instruction-supply
+    # study never land in the same file: their bytes_per_second columns are not
+    # comparable, and a reader cannot tell them apart from the JSON alone.
+    suffix="icache"
+    export VPHILOX_PERF_COUNTERS=1
+fi
 
 BENCH="$REPO/build/bench/benchmarks/$target"
 JSON="$OUTDIR/$tag-$suffix.json"
@@ -164,6 +187,7 @@ echo "==> capturing environment to $ENVFILE"
     echo "nproc: $(nproc 2>/dev/null || echo unknown)"
     echo "governor: $(cat "${GOV_PATHS[0]}" 2>/dev/null || echo unavailable)"
     echo "perf_event_paranoid: $(cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || echo n/a)"
+    echo "perf-counters: $([[ "$perf_counters" == 1 ]] && echo on || echo off)"
     # The write-ups quote a compiler version, and a benchmark number without one
     # is not reproducible: the same source on the same part gives different
     # results across GCC releases.
@@ -225,6 +249,20 @@ if ! grep -q '"cycles_per_byte"' "$JSON"; then
     exit 1
 fi
 
+# Same failure shape as above, one level up: with --perf-counters the whole
+# point of the run is icache_mpki, and a denied PMU drops the counter rather
+# than reporting a zero (bench_cycles.hpp is deliberate about that). A run that
+# lost it is not a quieter result, it is no result.
+if [[ "$perf_counters" == 1 ]] && ! grep -q '"icache_mpki"' "$JSON"; then
+    echo >&2
+    echo "ERROR: no icache_mpki in $JSON -- the perf counters did not run." >&2
+    echo "  perf_event_open was denied, or this host exposes no PMU. Try:" >&2
+    echo "    sudo sysctl -w kernel.perf_event_paranoid=1" >&2
+    echo "  Cloud instances frequently expose no vPMU at all, in which case" >&2
+    echo "  this study cannot be run on this host." >&2
+    exit 1
+fi
+
 # The binary stamps the resolved kernel into the JSON context, which is the one
 # fact the environment capture above cannot know: it runs before the benchmark,
 # and dispatch resolves inside it. Mirror it into the environment file so the
@@ -250,14 +288,26 @@ for b in rows:
         cv[name[:-3]] = b
 
 noisy = []
-print(f"{'benchmark':<42}{'cycles/byte':>13}{'GiB/s':>10}{'cv':>9}")
+# The MPKI columns only exist on a --perf-counters run; show them only then,
+# so the ordinary scaling table keeps its shape.
+has_mpki = any("icache_mpki" in b for b in med.values())
+head = f"{'benchmark':<42}{'cycles/byte':>13}{'GiB/s':>10}{'cv':>9}"
+if has_mpki:
+    head += f"{'i$ MPKI':>10}{'instr/B':>10}"
+print(head)
 for name, b in med.items():
     cpb = b.get("cycles_per_byte")
     gib = b.get("bytes_per_second", 0) / (1 << 30)
     c   = cv.get(name, {}).get("cycles_per_byte")
     cvs = f"{c*100:.2f}%" if c is not None else "n/a"
     cpbs = f"{cpb:.4f}" if cpb is not None else "n/a"
-    print(f"{name.replace('/real_time', ''):<42}{cpbs:>13}{gib:>10.3f}{cvs:>9}")
+    line = f"{name.replace('/real_time', ''):<42}{cpbs:>13}{gib:>10.3f}{cvs:>9}"
+    if has_mpki:
+        mpki = b.get("icache_mpki")
+        ipb  = b.get("instructions_per_byte")
+        line += f"{mpki:>10.3f}" if mpki is not None else f"{'n/a':>10}"
+        line += f"{ipb:>10.3f}" if ipb is not None else f"{'n/a':>10}"
+    print(line)
     if c is not None and c > 0.01:
         noisy.append((name, c))
 


### PR DESCRIPTION
Builds the harness half of #53: `--perf-counters` on a scaling run gives per-worker `icache_mpki` and `instructions_per_byte`, archived to `<tag>-icache.json` so an instruction-supply study never overwrites the throughput curve it exists to explain.

Neither libpfm nor `--benchmark_perf_counters` is involved, and both were the original plan. Google Benchmark starts and stops its counters on the thread running the benchmark loop (`benchmark.cc`, in `State::ResumeTiming`), and in this pool-driven benchmark that thread is the dispatcher: on the std::thread path it blocks on a condition variable while the workers do every instruction, and on the OpenMP path it is the team master and does 1/N of the work. Either way the row would have looked like an aggregate and been one worker's share or nothing at all. Per-worker counters summed the way `cycle_counter` already is are the only shape that answers the question -- and that also removes the dependency, because retired instructions and L1 i-cache read misses are both generic perf_event_open events.

Opt-in, because the extra ioctl pair per worker per iteration lands in wall time: the published scaling rows must not move because a diagnostic was added. Only `icache_mpki` and `instructions_per_byte` are quotable from an i-cache run; its `bytes_per_second` is not comparable with the scaling curve, which is why the two go to different files.

Three guards, since a wrong number here would pass for a right one:

- A denied PMU drops the counter instead of reporting a zero. MPKI of 0.00 is a plausible answer to this question, so it must never be what a missing vPMU produces. Verified by starving the process of file descriptors: the row reports `perf_counters=unavailable` and emits no counter.
- `run_matrix.sh` exits non-zero when an `--perf-counters` run produced no `icache_mpki`, the same shape as the existing cycles_per_byte check.
- `instructions_per_byte` is the self-check: it is a property of the kernel, so it must not move with thread count. Measured invariant to six digits from 1 to 8 threads and 0.00% CV across repetitions, which is what says the counters attached to the right threads.

The measurement itself still wants the pinned 16-core host from #51. The question is narrow: #51 concluded the hyperthread knee is execution-port contention, and the standing alternative is two workers on one core thrashing a shared instruction cache, these kernels being large unrolled bodies. MPKI flat across the co-location boundary excludes it; MPKI that climbs does not.