### PR TITLE
Cross-check the stream against NVIDIA cuRAND

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,19 @@ not just a byte stream. TestU01 ships under a non-permissive licence, so it is
 never vendored — the `vphilox_testu01` target simply does not exist unless the
 library is installed, and configure logs which case you are in.
 
+`tools/vphilox_curand_parity` is the third of these and follows the same
+optional-target rule: it exists only when the cuRAND headers are found, and
+**CUDA never becomes a dependency of the library.** It cross-checks the stream
+against NVIDIA cuRAND and documents the seeding mapping between them
+(`docs/curand-parity.md`) — cuRAND's `subsequence` is the counter's high 64
+bits, `offset / 4` the low 64, `offset % 4` a word index, so cuRAND's `offset`
+counts *words* where a vphilox counter counts *blocks of four*. It needs no GPU
+and no `nvcc`: cuRAND guards its decoration with `#if !defined(QUALIFIERS)`, so
+the tool compiles NVIDIA's reference implementation as host C++. Do not
+"upgrade" it to a real device build expecting a stronger result — the only
+target-dependent line in the generator is `mulhilo32`, whose host and device
+branches compute the same product.
+
 ```bash
 scripts/statistical/build_practrand.sh    # PractRand pre0.95 -> ~/.local/src
 scripts/statistical/build_testu01.sh      # TestU01 -> ~/.local

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,9 +20,10 @@ particular) is a comparison worth *reporting* honestly, not a target to chase.
 Derived from `docs/VPhilox Development Phases.md` and
 `docs/Vector Philox Development Strategy.md`.
 
-**Status:** Phases 0-3 complete; Phase 4 complete except a cuRAND/GPU parity
-reference. The instruction-cache study is now measured — a bare-metal Tiger Lake
-laptop cleared the co-location gate that no earlier host could.
+**Status:** Phases 0-3 complete; **Phase 4 complete.** The instruction-cache
+study is measured — a bare-metal Tiger Lake laptop cleared the co-location gate
+that no earlier host could — and the cuRAND cross-check is done without needing
+a GPU at all.
 Current version
 `2026.08.0` (see [VERSIONING.md](VERSIONING.md)).
 
@@ -512,7 +513,7 @@ and whose state can be written on one platform and read on another.
           across independent runs, and the finding is a direction rather than a
           threshold, so the conclusion survives — but the cycles/byte column here
           is a weaker version of what #51 already measured on better hardware
-- [~] **Cross-platform bit parity** — same key and counter produce identical output on x86-64,
+- [x] **Cross-platform bit parity** — same key and counter produce identical output on x86-64,
       aarch64, and (if reachable) a cuRAND/GPU reference. This is the reproducibility claim;
       it needs a test, not an assertion.
   - [x] `tests/test_cross_platform_parity.cpp` folds an 8191-block stream into an FNV-1a
@@ -527,7 +528,29 @@ and whose state can be written on one platform and read on another.
         therefore now known to be identical on x86-64 scalar, AVX2, AVX-512 and aarch64
         NEON — four kernels, two architectures, three compilers. That is the
         reproducibility claim discharged by measurement rather than by assertion
-  - [ ] cuRAND/GPU reference, if reachable
+  - [x] **Cross-checked against NVIDIA cuRAND** (`docs/curand-parity.md`). 16/16
+        cases identical over 4096 words each, under `scalar`, `avx2` and
+        `avx512`. Two independent assertions per case: the *core*, feeding
+        cuRAND's own reported (counter, key) into vphilox, and the *mapping*,
+        that those values match what `(seed, subsequence, offset)` predicts.
+        Both were mutation-tested — swapping the predicted counter halves fails
+        mapping only (7/16), flipping one counter bit fails core only (0/16) —
+        so they are two tests rather than one written twice
+    - [x] **No GPU or nvcc needed, which makes it portable rather than weaker.**
+          cuRAND guards its decoration with `#if !defined(QUALIFIERS)`, so the
+          tool compiles NVIDIA's reference implementation as host C++. The only
+          target-dependent line in the generator is `mulhilo32`, whose host and
+          device branches both compute the high 32 bits of a 32x32 product. What
+          is unverified is NVIDIA's *device codegen*, not the algorithm, and
+          `docs/curand-parity.md` says so rather than glossing it
+    - [x] The interop mapping is now documented: cuRAND's `subsequence` occupies
+          the counter's high 64 bits, `offset / 4` the low 64, and `offset % 4`
+          is a word index into the block — so cuRAND's `offset` counts words
+          where a vphilox counter counts blocks of four. That asymmetry is the
+          part a caller would otherwise get wrong
+    - [x] Optional exactly as `vphilox_testu01` is: the target does not exist
+          unless the cuRAND headers are found, and configure logs which case you
+          are in. CUDA never becomes a dependency of the library
 - [x] Publish plots and raw CSVs under `docs/benchmarks/` —
       `scripts/benchmarks/publish_results.py` generates
       [`docs/benchmarks/raw/`](docs/benchmarks/raw) and

--- a/docs/curand-parity.md
+++ b/docs/curand-parity.md
@@ -1,0 +1,146 @@
+# Interoperating with cuRAND
+
+vphilox produces the same stream as NVIDIA cuRAND's `Philox4_32_10`, and this
+page records both the verification and the seeding mapping that makes it usable.
+
+**Verified: 16/16 cases identical over 4096 words each, under all three x86
+backends.** Log: [`results/curand/curand-parity-tigerlake.txt`](../results/curand/curand-parity-tigerlake.txt).
+
+## Why this is a separate question from #54's parity test
+
+`tests/test_cross_platform_parity.cpp` proves vphilox agrees with *itself*
+across architectures — four kernels, two architectures, one FNV-1a digest. And
+`tests/test_reference_vectors.cpp` pins the core function to the published
+Salmon et al. vectors, so agreement on the *algorithm* was never really in
+doubt.
+
+Neither says anything about the layer where implementations actually diverge.
+cuRAND seeds with `(seed, subsequence, offset)`; vphilox seeds with
+`(key, counter)`. Philox implementations agree on the round function and
+disagree on exactly this mapping, and for a library whose reason for existing is
+portable, reproducible state, "the same stream on both sides" is a claim worth
+establishing rather than assuming.
+
+## The mapping
+
+`curand_init(seed, subsequence, offset, &state)` zeroes the counter, adds
+`subsequence` to its **high** 64 bits, adds `offset / 4` to its **low** 64 bits,
+and keeps `offset % 4` as a word index into the resulting block. vphilox's
+`counter4` is little-endian by word, so:
+
+| cuRAND | vphilox |
+|---|---|
+| `seed` (low 32) | `key.v[0]` |
+| `seed` (high 32) | `key.v[1]` |
+| `offset / 4` (low 32) | `counter.v[0]` |
+| `offset / 4` (high 32) | `counter.v[1]` |
+| `subsequence` (low 32) | `counter.v[2]` |
+| `subsequence` (high 32) | `counter.v[3]` |
+| `offset % 4` | word index within the block |
+
+So to resume a cuRAND stream in vphilox:
+
+```cpp
+const std::uint64_t lo = offset / 4;
+vphilox::key2     key{{u32(seed),      u32(seed >> 32)}};
+vphilox::counter4 ctr{{u32(lo), u32(lo >> 32), u32(subsequence), u32(subsequence >> 32)}};
+
+vphilox::engine eng(key, ctr);
+// then discard `offset % 4` words to land exactly where cuRAND would be
+```
+
+Note the asymmetry worth remembering: cuRAND's `offset` counts **words**, while
+a vphilox counter counts **blocks of four**. An `offset` that is not a multiple
+of four lands mid-block, which is what the word index is for.
+
+The practical consequence is that cuRAND's subsequences are `2^66` values apart
+— it reserves the counter's entire high 64 bits for stream selection and leaves
+the low 64 for position. A caller partitioning work across GPU threads the
+cuRAND way and across CPU threads the vphilox way gets identical, non-
+overlapping streams as long as both use the same convention.
+
+## How it is checked
+
+`tools/vphilox_curand_parity` runs sixteen cases and makes two *independent*
+assertions per case:
+
+1. **Core.** cuRAND reports its own `(counter, key)` after seeding. Those exact
+   values are fed to vphilox and the two word streams must match over 4096
+   words. This tests the round function and counter increment order with no
+   assumption about seeding at all.
+2. **Mapping.** The `(counter, key)` cuRAND derived must equal what the table
+   above predicts from `(seed, subsequence, offset)`.
+
+Splitting them matters: check 1 would pass even if the mapping were completely
+wrong, because it takes cuRAND's word for the state. Check 2 is the interop
+claim, and it is the half that could plausibly have failed.
+
+Cases cover block-aligned and mid-block offsets, offsets straddling `2^32`
+(forcing a carry between the counter's low words), the maximum subsequence, and
+edge keys including all-zero and all-ones.
+
+### The checks are proven sensitive
+
+Both assertions were mutation-tested rather than assumed to work:
+
+| mutation | core | mapping |
+|---|---|---|
+| *(none)* | 16/16 | 16/16 |
+| predicted counter halves swapped | 16/16 | **7/16** |
+| one bit flipped in the counter given to vphilox | **0/16** | 16/16 |
+
+Each mutation is caught by exactly one check and passes the other, which is what
+demonstrates they are two independent tests rather than one written twice. The
+seven survivors of the first mutation are the cases whose counter halves are
+both zero, where swapping them is a no-op.
+
+## No GPU, and why that is not a weaker result
+
+The tool needs the CUDA **headers** and nothing else — no `nvcc`, no CUDA
+runtime, no GPU. cuRAND guards its function decoration with
+`#if !defined(QUALIFIERS)`, so defining `QUALIFIERS` before the include compiles
+NVIDIA's own reference implementation as ordinary host C++.
+
+The arithmetic is identical either way by construction. The only
+target-dependent line in the entire generator is `mulhilo32`, which cuRAND
+writes as `NV_IF_ELSE_TARGET(NV_IS_HOST, <64-bit multiply>, __umulhi)`. Both
+branches compute the high 32 bits of a 32×32 product; the difference is
+instruction selection, not algorithm.
+
+So what is verified is NVIDIA's reference implementation, not NVIDIA's device
+code generation. The gap between those is a hypothetical `__umulhi` bug rather
+than anything about Philox — but it *is* a gap, and it is stated here rather
+than glossed. Anyone wanting to close it can run the same cases through a real
+device build.
+
+This also makes the check far more portable than a GPU test would have been: it
+runs on any machine with the CUDA toolkit unpacked, and needs no NVIDIA hardware
+at all.
+
+## Running it
+
+The target only exists when the cuRAND headers are found, exactly as
+`vphilox_testu01` only exists when TestU01 is installed. Configure logs which
+case you are in.
+
+```bash
+cmake --preset default && cmake --build --preset default --target vphilox_curand_parity
+build/tools/vphilox_curand_parity                       # resolved backend
+VPHILOX_BACKEND=scalar build/tools/vphilox_curand_parity  # or pin one
+```
+
+Exit status is 0 for `IDENTICAL` and 1 for `MISMATCH`, so it can be wired into a
+script. It is not a CTest case because it needs a third-party header that most
+machines do not have.
+
+## Recorded run
+
+Tiger Lake i5-11300H, GCC 15.2.0, cuRAND headers 10401 (CUDA 13.1), all sixteen
+cases identical under `scalar`, `avx2` and `avx512`.
+
+An RTX 3060 is present in that machine and was deliberately not used: its CUDA
+13.1 toolkit cannot compile even an empty `.cu` against the host's glibc 2.43
+(`rsqrt` is declared with incompatible exception specifications by
+`crt/math_functions.h` and `bits/mathcalls.h`). That blocked the device route
+entirely — and prompted the host-compiled approach, which turned out to be the
+better artifact.

--- a/results/curand/curand-parity-tigerlake.txt
+++ b/results/curand/curand-parity-tigerlake.txt
@@ -1,0 +1,105 @@
+# vphilox <-> cuRAND Philox4_32_10 parity run
+date_utc:     2026-08-25T20:01:30Z
+host:         parthsinha
+cpu:          11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz
+gpu:          NVIDIA GeForce RTX 3060 Laptop GPU (present but unused; see note)
+cuda_headers: /usr/local/cuda-13.1/
+compiler:     c++ (Ubuntu 15.2.0-16ubuntu1) 15.2.0
+git_sha:      a34b71fb4a063d1cb69c7976d081cbf028075fd8
+command:      for b in scalar avx2 avx512; do VPHILOX_BACKEND=$b build/tools/vphilox_curand_parity; done
+#
+# No GPU or nvcc is involved: cuRAND's own reference implementation is
+# compiled as host C++ by overriding its QUALIFIERS macro. The only
+# target-dependent line in the generator is mulhilo32, whose host and
+# device branches compute the same 32x32->high-32 product.
+#
+=== VPHILOX_BACKEND=scalar ===
+# vphilox <-> cuRAND Philox4_32_10 parity
+# vphilox version : 2026.08.0
+# vphilox backend : scalar
+# curand headers  : 10401
+# curand build    : host (QUALIFIERS overridden; no device code)
+# words per case  : 4096
+#
+origin                   core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00000000  w0
+plain seed               core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:deadbeef  w0
+64-bit seed              core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 01234567:89abcdef  w0
+all-ones seed            core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key ffffffff:ffffffff  w0
+offset 1 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w1
+offset 2 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w2
+offset 3 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w3
+offset 4 (next block)    core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w0
+offset 7 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w3
+subsequence 1            core OK    mapping OK    ctr 00000000:00000001:00000000:00000000  key 00000000:00000063  w0
+subsequence 2^32         core OK    mapping OK    ctr 00000001:00000000:00000000:00000000  key 00000000:00000063  w0
+subsequence max          core OK    mapping OK    ctr ffffffff:ffffffff:00000000:00000000  key 00000000:00000063  w0
+offset across 2^32       core OK    mapping OK    ctr 00000000:00000000:00000001:00000000  key 00000000:00000007  w0
+offset carry boundary    core OK    mapping OK    ctr 00000000:00000000:00000000:ffffffff  key 00000000:00000007  w0
+both set                 core OK    mapping OK    ctr 00000000:00001234:00000000:00000400  key feedface:cafebeef  w0
+both large               core OK    mapping OK    ctr 00000000:ffffffff:00000040:00000002  key a5a5a5a5:a5a5a5a5  w1
+#
+# core    : 16/16 cases identical over 4096 words each
+# mapping : 16/16 cases match the documented derivation
+# VERDICT : IDENTICAL
+exit: 0
+
+=== VPHILOX_BACKEND=avx2 ===
+# vphilox <-> cuRAND Philox4_32_10 parity
+# vphilox version : 2026.08.0
+# vphilox backend : avx2
+# curand headers  : 10401
+# curand build    : host (QUALIFIERS overridden; no device code)
+# words per case  : 4096
+#
+origin                   core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00000000  w0
+plain seed               core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:deadbeef  w0
+64-bit seed              core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 01234567:89abcdef  w0
+all-ones seed            core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key ffffffff:ffffffff  w0
+offset 1 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w1
+offset 2 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w2
+offset 3 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w3
+offset 4 (next block)    core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w0
+offset 7 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w3
+subsequence 1            core OK    mapping OK    ctr 00000000:00000001:00000000:00000000  key 00000000:00000063  w0
+subsequence 2^32         core OK    mapping OK    ctr 00000001:00000000:00000000:00000000  key 00000000:00000063  w0
+subsequence max          core OK    mapping OK    ctr ffffffff:ffffffff:00000000:00000000  key 00000000:00000063  w0
+offset across 2^32       core OK    mapping OK    ctr 00000000:00000000:00000001:00000000  key 00000000:00000007  w0
+offset carry boundary    core OK    mapping OK    ctr 00000000:00000000:00000000:ffffffff  key 00000000:00000007  w0
+both set                 core OK    mapping OK    ctr 00000000:00001234:00000000:00000400  key feedface:cafebeef  w0
+both large               core OK    mapping OK    ctr 00000000:ffffffff:00000040:00000002  key a5a5a5a5:a5a5a5a5  w1
+#
+# core    : 16/16 cases identical over 4096 words each
+# mapping : 16/16 cases match the documented derivation
+# VERDICT : IDENTICAL
+exit: 0
+
+=== VPHILOX_BACKEND=avx512 ===
+# vphilox <-> cuRAND Philox4_32_10 parity
+# vphilox version : 2026.08.0
+# vphilox backend : avx512
+# curand headers  : 10401
+# curand build    : host (QUALIFIERS overridden; no device code)
+# words per case  : 4096
+#
+origin                   core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00000000  w0
+plain seed               core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:deadbeef  w0
+64-bit seed              core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 01234567:89abcdef  w0
+all-ones seed            core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key ffffffff:ffffffff  w0
+offset 1 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w1
+offset 2 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w2
+offset 3 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000000  key 00000000:00003039  w3
+offset 4 (next block)    core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w0
+offset 7 (mid-block)     core OK    mapping OK    ctr 00000000:00000000:00000000:00000001  key 00000000:00003039  w3
+subsequence 1            core OK    mapping OK    ctr 00000000:00000001:00000000:00000000  key 00000000:00000063  w0
+subsequence 2^32         core OK    mapping OK    ctr 00000001:00000000:00000000:00000000  key 00000000:00000063  w0
+subsequence max          core OK    mapping OK    ctr ffffffff:ffffffff:00000000:00000000  key 00000000:00000063  w0
+offset across 2^32       core OK    mapping OK    ctr 00000000:00000000:00000001:00000000  key 00000000:00000007  w0
+offset carry boundary    core OK    mapping OK    ctr 00000000:00000000:00000000:ffffffff  key 00000000:00000007  w0
+both set                 core OK    mapping OK    ctr 00000000:00001234:00000000:00000400  key feedface:cafebeef  w0
+both large               core OK    mapping OK    ctr 00000000:ffffffff:00000040:00000002  key a5a5a5a5:a5a5a5a5  w1
+#
+# core    : 16/16 cases identical over 4096 words each
+# mapping : 16/16 cases match the documented derivation
+# VERDICT : IDENTICAL
+exit: 0
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -41,3 +41,33 @@ else()
     message(STATUS "vphilox: TestU01 not found, skipping vphilox_testu01 "
                    "(run scripts/statistical/build_testu01.sh)")
 endif()
+
+# vphilox_curand_parity: cross-check the stream against NVIDIA cuRAND (#54).
+# Optional in exactly the way vphilox_testu01 is -- the target does not exist
+# unless the cuRAND headers are installed, and CUDA is never a dependency of
+# the library itself.
+#
+# Headers only: no nvcc, no CUDA runtime, no GPU. cuRAND guards its function
+# decoration with `#if !defined(QUALIFIERS)`, so the tool defines QUALIFIERS
+# and compiles NVIDIA's reference implementation as host C++ with the same
+# compiler as everything else. That is what lets this run on any machine with
+# the CUDA toolkit unpacked, rather than only on a GPU box -- see the note at
+# the top of vphilox_curand_parity.cpp for why it is not a weaker check.
+find_path(CURAND_INCLUDE_DIR curand_kernel.h
+    HINTS ENV CUDA_HOME ENV CUDA_PATH PATH_SUFFIXES include
+    PATHS /usr/local/cuda/include /usr/local/cuda/targets/x86_64-linux/include
+          /opt/cuda/include /usr/include)
+
+if(CURAND_INCLUDE_DIR)
+    add_executable(vphilox_curand_parity vphilox_curand_parity.cpp)
+    target_link_libraries(vphilox_curand_parity PRIVATE vphilox::vphilox)
+    target_include_directories(vphilox_curand_parity PRIVATE ${CURAND_INCLUDE_DIR})
+    target_compile_features(vphilox_curand_parity PRIVATE cxx_std_20)
+    if(NOT MSVC)
+        target_compile_options(vphilox_curand_parity PRIVATE -O3)
+    endif()
+    message(STATUS "vphilox: cuRAND headers found, building vphilox_curand_parity")
+else()
+    message(STATUS "vphilox: cuRAND headers not found, skipping vphilox_curand_parity "
+                   "(install the CUDA toolkit headers to enable the cross-check)")
+endif()

--- a/tools/vphilox_curand_parity.cpp
+++ b/tools/vphilox_curand_parity.cpp
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Parth Sinha
+
+// vphilox_curand_parity: does vphilox produce the same stream as NVIDIA cuRAND?
+//
+// Issue #54's parity claim was discharged across x86-64 (scalar, AVX2,
+// AVX-512) and aarch64 (NEON) by `tests/test_cross_platform_parity.cpp`. That
+// covers this library's own kernels. This tool answers a different question:
+// does vphilox agree with somebody *else's* Philox4x32-10?
+//
+// `tests/test_reference_vectors.cpp` already pins the core function against the
+// published Salmon et al. vectors, so agreement on the algorithm is not really
+// in doubt. What is worth checking is the layer above it, which the KAT vectors
+// say nothing about: cuRAND seeds with (seed, subsequence, offset) and vphilox
+// with (key, counter). Implementations of Philox agree on the round function
+// and disagree on exactly this mapping. For a library whose entire reason for
+// existing is portable, reproducible state, "you get the same stream moving
+// between cuRAND and vphilox" is a claim worth either establishing or
+// explicitly disclaiming.
+//
+// Two independent things are checked:
+//
+//   1. CORE. cuRAND reports its own (counter, key) after seeding. Feed exactly
+//      those into vphilox and the word streams must be identical. This tests
+//      the round function and the counter increment order with no guesswork
+//      about seeding at all.
+//
+//   2. MAPPING. The (counter, key) cuRAND derived must match what this file
+//      predicts from (seed, subsequence, offset). This is the interop claim,
+//      and it is the half that could plausibly fail.
+//
+// ---------------------------------------------------------------------------
+// Why there is no CUDA here, and why that is not a weaker test
+//
+// cuRAND's Philox header guards its function decoration with
+// `#if !defined(QUALIFIERS)`, so defining QUALIFIERS before including it
+// compiles NVIDIA's own reference implementation as ordinary host C++. No nvcc,
+// no GPU, no container — the tool needs the CUDA *headers* and nothing else,
+// which is what makes it runnable anywhere rather than only on a GPU box.
+//
+// The arithmetic is the same either way by construction. The only target-
+// dependent line in the whole generator is `mulhilo32`, which cuRAND writes as
+// NV_IF_ELSE_TARGET(NV_IS_HOST, 64-bit multiply, __umulhi). Both branches
+// compute the high 32 bits of a 32x32 product; the difference is instruction
+// selection, not algorithm. So this checks NVIDIA's reference implementation
+// and not NVIDIA's device code generation, and the gap between those two is a
+// hypothetical `__umulhi` bug rather than anything about Philox.
+//
+// Build: only exists when the cuRAND headers are found. See tools/CMakeLists.txt.
+
+// Must precede the cuRAND include: it is what turns __device__ code into
+// host code. See the note above.
+#define QUALIFIERS static inline
+
+#include <curand_kernel.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "vphilox/vphilox.hpp"
+
+namespace {
+
+struct case_spec {
+    const char* what;
+    unsigned long long seed;
+    unsigned long long subseq;
+    unsigned long long offset;
+};
+
+// Chosen to exercise the seeding arithmetic rather than just the round
+// function: offsets that are not block-aligned land mid-block and shift the
+// word index, and values straddling 2^32 force a carry between the counter's
+// low and high words, which is where a mapping bug would actually live.
+constexpr case_spec cases[] = {
+    {"origin", 0, 0, 0},
+    {"plain seed", 0xDEADBEEFu, 0, 0},
+    {"64-bit seed", 0x0123456789ABCDEFull, 0, 0},
+    {"all-ones seed", ~0ull, 0, 0},
+    {"offset 1 (mid-block)", 12345, 0, 1},
+    {"offset 2 (mid-block)", 12345, 0, 2},
+    {"offset 3 (mid-block)", 12345, 0, 3},
+    {"offset 4 (next block)", 12345, 0, 4},
+    {"offset 7 (mid-block)", 12345, 0, 7},
+    {"subsequence 1", 99, 1, 0},
+    {"subsequence 2^32", 99, 1ull << 32, 0},
+    {"subsequence max", 99, ~0ull, 0},
+    {"offset across 2^32", 7, 0, 1ull << 34},
+    {"offset carry boundary", 7, 0, (1ull << 34) - 4},
+    {"both set", 0xFEEDFACECAFEBEEFull, 0x1234, 4096},
+    {"both large", 0xA5A5A5A5A5A5A5A5ull, 0xFFFFFFFFull, (1ull << 40) + 9},
+};
+
+constexpr std::size_t words_per_case = 4096;
+
+vphilox::counter4 predicted_counter(unsigned long long subseq, unsigned long long offset) {
+    // curand_init zeroes the counter, adds `subsequence` to its high 64 bits,
+    // then adds `offset / 4` to the low 64 bits and keeps `offset % 4` as a
+    // word index within the block. vphilox's counter4 is little-endian by word,
+    // so the low 64 bits are words 0-1 and the high 64 bits are words 2-3.
+    const unsigned long long lo = offset / 4;
+    return vphilox::counter4{{static_cast<vphilox::u32>(lo), static_cast<vphilox::u32>(lo >> 32),
+                              static_cast<vphilox::u32>(subseq),
+                              static_cast<vphilox::u32>(subseq >> 32)}};
+}
+
+vphilox::key2 predicted_key(unsigned long long seed) {
+    return vphilox::key2{{static_cast<vphilox::u32>(seed), static_cast<vphilox::u32>(seed >> 32)}};
+}
+
+std::string hex_counter(const vphilox::counter4& c) {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%08x:%08x:%08x:%08x", c.v[3], c.v[2], c.v[1], c.v[0]);
+    return buf;
+}
+
+}  // namespace
+
+int main() {
+    std::printf("# vphilox <-> cuRAND Philox4_32_10 parity\n");
+    std::printf("# vphilox version : %s\n", VPHILOX_VERSION_STRING);
+    std::printf("# vphilox backend : %s\n", vphilox::backend_name(vphilox::active_backend()));
+#ifdef CURAND_VERSION
+    std::printf("# curand headers  : %d\n", CURAND_VERSION);
+#endif
+    std::printf("# curand build    : host (QUALIFIERS overridden; no device code)\n");
+    std::printf("# words per case  : %zu\n", words_per_case);
+    std::printf("#\n");
+
+    std::vector<unsigned int> ref(words_per_case);
+    std::vector<vphilox::u32> ours;
+
+    std::size_t core_failures    = 0;
+    std::size_t mapping_failures = 0;
+
+    for (const auto& c : cases) {
+        curandStatePhilox4_32_10_t st;
+        curand_init(c.seed, c.subseq, c.offset, &st);
+
+        // Captured before a single word is drawn, so it describes the state
+        // that produces ref[0].
+        const vphilox::counter4 curand_ctr{{st.ctr.x, st.ctr.y, st.ctr.z, st.ctr.w}};
+        const vphilox::key2 curand_key{{st.key.x, st.key.y}};
+        const unsigned int word_index = st.STATE;
+
+        // Word at a time rather than curand4(). curand4() re-splices its return
+        // value when the generator sits mid-block, so drawing single words is
+        // the form that behaves identically for aligned and unaligned offsets.
+        for (std::size_t i = 0; i < words_per_case; ++i) {
+            ref[i] = curand(&st);
+        }
+
+        // --- check 1: the core, using cuRAND's own reported state ---
+        //
+        // vphilox starts at word 0 of the block; cuRAND starts at `word_index`
+        // of the same block, so generate the extra words and skip them rather
+        // than adjusting the counter, which would be the easy way to write a
+        // test that agrees with itself.
+        ours.assign(words_per_case + word_index, 0);
+        vphilox::engine eng(curand_key, curand_ctr);
+        eng.generate_n(ours.data(), ours.size());
+
+        std::size_t mismatch = words_per_case;
+        for (std::size_t i = 0; i < words_per_case; ++i) {
+            if (ours[i + word_index] != ref[i]) {
+                mismatch = i;
+                break;
+            }
+        }
+
+        // --- check 2: the seeding mapping this file documents ---
+        const bool mapping_ok = predicted_counter(c.subseq, c.offset) == curand_ctr &&
+                                predicted_key(c.seed) == curand_key &&
+                                word_index == (c.offset & 3u);
+
+        const bool core_ok = mismatch == words_per_case;
+        core_failures += core_ok ? 0 : 1;
+        mapping_failures += mapping_ok ? 0 : 1;
+
+        std::printf("%-24s core %-4s  mapping %-4s  ctr %s  key %08x:%08x  w%u\n", c.what,
+                    core_ok ? "OK" : "FAIL", mapping_ok ? "OK" : "FAIL",
+                    hex_counter(curand_ctr).c_str(), curand_key.v[1], curand_key.v[0], word_index);
+
+        if (!core_ok) {
+            std::printf("    first mismatch at word %zu: vphilox %08x, cuRAND %08x\n", mismatch,
+                        ours[mismatch + word_index], ref[mismatch]);
+        }
+        if (!mapping_ok) {
+            std::printf("    predicted ctr %s, key %08x:%08x, w%llu\n",
+                        hex_counter(predicted_counter(c.subseq, c.offset)).c_str(),
+                        predicted_key(c.seed).v[1], predicted_key(c.seed).v[0], c.offset & 3ull);
+        }
+    }
+
+    const std::size_t n = sizeof(cases) / sizeof(cases[0]);
+    std::printf("#\n");
+    std::printf("# core    : %zu/%zu cases identical over %zu words each\n", n - core_failures, n,
+                words_per_case);
+    std::printf("# mapping : %zu/%zu cases match the documented derivation\n", n - mapping_failures,
+                n);
+
+    if (core_failures == 0 && mapping_failures == 0) {
+        std::printf("# VERDICT : IDENTICAL\n");
+        return 0;
+    }
+    std::printf("# VERDICT : MISMATCH\n");
+    return 1;
+}


### PR DESCRIPTION
Closes #54.

Discharges the last open sub-item of the cross-platform parity claim — and does it without needing a GPU.

## The gap this fills

`tests/test_cross_platform_parity.cpp` proves vphilox agrees with *itself* across four kernels and two architectures. `tests/test_reference_vectors.cpp` pins the core function to the published Salmon et al. vectors. Neither touches the layer where Philox implementations actually diverge: cuRAND seeds with `(seed, subsequence, offset)`, vphilox with `(key, counter)`.

They line up. **16/16 cases identical over 4096 words each, under `scalar`, `avx2` and `avx512`.**

## The mapping, now documented

| cuRAND | vphilox |
|---|---|
| `seed` low / high 32 | `key.v[0]` / `key.v[1]` |
| `offset / 4` low / high 32 | `counter.v[0]` / `counter.v[1]` |
| `subsequence` low / high 32 | `counter.v[2]` / `counter.v[3]` |
| `offset % 4` | word index within the block |

The asymmetry a caller would otherwise get wrong: cuRAND's `offset` counts **words**, a vphilox counter counts **blocks of four**.

## Two independent checks, both proven sensitive

The *core* check feeds cuRAND's own reported `(counter, key)` into vphilox, so it tests the round function and increment order while assuming nothing about seeding. The *mapping* check asserts those values are what `(seed, subsequence, offset)` predicts.

Mutation-tested rather than assumed:

| mutation | core | mapping |
|---|---|---|
| *(none)* | 16/16 | 16/16 |
| predicted counter halves swapped | 16/16 | **7/16** |
| one bit flipped in vphilox's counter | **0/16** | 16/16 |

Each is caught by exactly one check — two tests, not one written twice.

## No GPU, no nvcc

cuRAND guards its decoration with `#if !defined(QUALIFIERS)`, so the tool compiles NVIDIA's reference implementation as host C++. The only target-dependent line in the generator is `mulhilo32`, whose host and device branches both compute the high 32 bits of a 32×32 product.

What that leaves unverified is NVIDIA's *device code generation*, not the algorithm. `docs/curand-parity.md` states this rather than glossing it. The upside is portability: the check runs on any machine with the CUDA headers unpacked, with no NVIDIA hardware at all.

The target is optional exactly as `vphilox_testu01` is — it does not exist unless the cuRAND headers are found, configure logs which case you are in, and **CUDA never becomes a dependency of the library.**

## Compatibility impact

None. One new optional tool, one doc, one archived log, plus ROADMAP/CLAUDE.md updates. No headers, kernels, or build defaults touched, so the bit stream is untouched by construction. 113/113 tests pass; the CI clang-format sweep is clean locally against the pinned 21.1.8.

## Incidental finding

The RTX 3060 in the machine that ran this was deliberately unused: its CUDA 13.1 toolkit cannot compile an empty `.cu` against the host's glibc 2.43, because `crt/math_functions.h` and `bits/mathcalls.h` declare `rsqrt` with incompatible exception specifications. That blocked the device route and prompted the host-compiled approach, which turned out to be the better artifact.