### PR TITLE
Stop calling Google Benchmark's observed clock a nominal rate

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -165,8 +165,17 @@ as a percentage, bytes/second, median wall time, and which counter supplied the
 cycles.
 
 `raw/machines.csv` — one row per archived run: label, resolved backend,
-measurement quality, CPU, nominal MHz, cycle source, date, commit, governor,
+measurement quality, CPU, reported MHz, cycle source, date, commit, governor,
 compiler, and the verbatim command.
+
+**`reported_mhz` is not a machine specification.** It is Google Benchmark's
+`mhz_per_cpu`, the clock it observed when the run started, so on a machine with
+a scaling governor at idle it can read an order of magnitude low: two Tiger Lake
+runs say 400 and 421 MHz for a part whose base clock is 3100, next to sibling
+runs of the same host on the same day saying 3090 and 3100. Nothing derived
+depends on it — cycles/byte comes from RDTSC or `perf_event_open` inside the
+benchmark, never from this column — so it is provenance, not input. For a
+host's actual clock, read the write-up.
 
 **Read the `quality` column before quoting a number.** Four archived runs do
 not meet the bar in `CLAUDE.md` — an unpinned governor puts a moving turbo

--- a/docs/benchmarks/raw/machines.csv
+++ b/docs/benchmarks/raw/machines.csv
@@ -1,4 +1,4 @@
-tag,label,backend,quality,arch,cpu,nominal_mhz,cycle_source,date,commit,governor,compiler,command
+tag,label,backend,quality,arch,cpu,reported_mhz,cycle_source,date,commit,governor,compiler,command
 avx2-baseline,Tiger Lake / AVX2,avx2,harness validation: unpinned governor,x86_64,11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz,4400,rdtsc,2026-08-23T09:50:31+01:00,,,g++ (Ubuntu 15.2.0-16ubuntu1) 15.2.0,
 avx512-baseline,Ice Lake SP,scalar,harness validation: 2-vCPU cloud VM,x86_64,Intel(R) Xeon(R) CPU @ 2.60GHz,2600,rdtsc,2026-08-22T09:54:10+00:00,,,,
 bulk-generate-baseline,Tiger Lake / AVX2,avx2,harness validation: unpinned governor,x86_64,11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz,4400,rdtsc,2026-08-23T11:06:10+01:00,,,,

--- a/paper/README.md
+++ b/paper/README.md
@@ -60,7 +60,7 @@ whenever a table is added.
 
 | Paper | Source |
 |---|---|
-| `tab:machines` | `docs/benchmarks/raw/machines.csv` |
+| `tab:machines` | `docs/benchmarks/raw/machines.csv`, except the MHz column — see below |
 | `tab:matrix` (relative matrix) | `docs/benchmarks/raw/*-matrix.csv`, five hosts |
 | `tab:avx512` (AVX-512 vs AVX2) | `docs/benchmarks/avx512-downclocking-2026-08-24.md` |
 | `tab:icache` (instruction supply) | `docs/benchmarks/icache-placement-tigerlake-2026-08-25.md` |
@@ -72,6 +72,13 @@ whenever a table is added.
 | `sec:placement` | `docs/benchmarks/scaling-cascade-lake-2026-08-25.md` |
 | `sec:stat` (statistics) | `docs/statistical-validation.md`, `results/practrand/`, `results/testu01/` |
 | `sec:curand` | `docs/curand-parity.md`, `results/curand/` |
+
+The one column not taken from the CSV is `tab:machines`'s MHz, which carries
+each host's nominal clock. `machines.csv` has a `reported_mhz` column, but that
+is Google Benchmark's reading of the clock at run start rather than a machine
+specification, and on an idle laptop it reads an order of magnitude low. The
+table's figures come from the per-host write-ups instead; see
+`docs/benchmarks/README.md`.
 
 The two new tables are tables and not figures on purpose. Both are two-arm
 contrasts of four numbers, which a plot makes harder to read rather than easier,

--- a/scripts/benchmarks/publish_results.py
+++ b/scripts/benchmarks/publish_results.py
@@ -281,7 +281,16 @@ def write_csvs(runs, outdir):
     path = os.path.join(rawdir, "machines.csv")
     with open(path, "w", encoding="utf-8", newline="\n") as fh:
         w = csv.writer(fh, lineterminator="\n")
-        w.writerow(["tag", "label", "backend", "quality", "arch", "cpu", "nominal_mhz",
+        # reported_mhz, not nominal_mhz. This is Google Benchmark's mhz_per_cpu,
+        # which is the clock it observed when the run started -- on a machine
+        # with a scaling governor at idle that is nowhere near the nominal rate.
+        # The archive has two Tiger Lake runs reading 400 and 421 MHz for a part
+        # whose base clock is 3100, alongside sibling runs of the same host on
+        # the same day reading 3090 and 3100. Nothing derived depends on it,
+        # because cycles/byte comes from RDTSC inside the benchmark, but the
+        # column was named as though it were a machine specification and it is
+        # not one.
+        w.writerow(["tag", "label", "backend", "quality", "arch", "cpu", "reported_mhz",
                     "cycle_source", "date", "commit", "governor", "compiler", "command"])
         for tag, run in sorted(runs.items()):
             ctx, env = run["context"], run["env"]


### PR DESCRIPTION
`machines.csv` had a column named `nominal_mhz` filled from the JSON context's `mhz_per_cpu`, which is Google Benchmark's reading of the clock **at the moment the run started**. On a machine with a scaling governor at idle that is not a nominal rate and not close to one:

| tag | reported | the part's base clock |
|---|---:|---:|
| `tigerlake-icache-phys` | 421 MHz | 3100 MHz |
| `tigerlake-omp-l1-default` | 400 MHz | 3100 MHz |
| `tigerlake-icache-ht` | 3090 MHz | 3100 MHz |
| `tigerlake-scaling` | 3100 MHz | 3100 MHz |

Same host, same day, four runs, a 7x spread in a column named as though it described the machine.

## Why this is a labelling defect and not a bad result

Nothing derived moves. Cycles per byte comes from RDTSC on x86 and `perf_event_open` on Linux ARM, read inside the benchmark, and never from this column. It is provenance, not input.

What was wrong is the name. A reader cross-checking the paper's machines table against the CSV would find the same host disagreeing with itself by an order of magnitude, and would have no way to tell which number to believe.

## What changed

Renamed to `reported_mhz`, with `docs/benchmarks/README.md` stating what it actually measures and why it can read an order of magnitude low. **Only the header line of `machines.csv` changes; every value is untouched** — `publish_results.py --check` passes after regenerating.

`paper/README.md` also gains a correction that is not about the rename: its source-mapping table claimed the paper's machines table came from `machines.csv`, but its MHz column always came from the per-host write-ups. That was the one row of that table that was wrong, and it is the row this issue would have led someone to.

## Compatibility

None. No file under `include/` is touched.

## Verification

- `publish_results.py --check` passes
- 113/113 tests on `default`, `debug` (-Werror) and `asan`