### PR TITLE
Correct the README's stale results and record the publishing route

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,14 @@ keywords:
   - high-performance computing
   - reproducibility
   - C++20
-# TODO(phase-5): add the Zenodo DOI here once assigned, and a preferred-citation
-# block pointing at the arXiv preprint.
+# TODO(phase-5): three edits at release time, in this order.
+#   1. Set `version` and `date-released` to the tag and the day it goes out.
+#      The date below is when this file was written, not a release date.
+#   2. Add `doi:` with the Zenodo DOI reserved for the tagged release.
+#   3. Add a `preferred-citation:` block for the TechRxiv preprint, and swap it
+#      for the arXiv version if and when that supersedes it.
+# `orcid:` under `authors` is worth filling in at the same time; Zenodo and
+# arXiv both ask for it. See docs/publishing-guide.md.
 references:
   - type: conference-paper
     title: "Parallel Random Numbers: As Easy as 1, 2, 3"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ enforces this against the published vectors; if it fails, the change is wrong.
 
 ## Adding a SIMD kernel
 
-This is Phase 2, and the scaffolding is already in place.
+Scalar, AVX2, AVX-512 and NEON are all implemented. A fifth kernel (SVE, say)
+follows the same five steps.
 
 1. Implement `generate()` in the kernel header, replacing the scalar
    fallthrough.
@@ -108,8 +109,21 @@ bespoke checks.
 Report cycles per byte alongside GB/s. GB/s is not comparable across machines,
 and the claims this project makes are cycle-level claims.
 
-Benchmark on a quiet machine with frequency scaling pinned. A 10% swing between
-runs on a laptop is thermal, not algorithmic.
+Run them through the harness rather than by hand:
+
+```bash
+scripts/benchmarks/run_matrix.sh --tag <machine> --cpu <isolated-cpu>
+```
+
+It rebuilds first, pins the governor and restores it on exit, writes a
+provenance file next to the JSON, and exits non-zero if any row moves more than
+1% between repetitions. A stale `build/` will otherwise run a months-old binary
+and print a plausible table. A 10% swing between runs on a laptop is thermal,
+not algorithmic, and the CV check is there to catch it.
+
+`docs/benchmarks/README.md` explains why cross-machine figures plot ratios
+measured inside each machine, and why a cloud VM is fine for correctness but not
+for throughput.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -19,20 +19,23 @@
 
 vphilox is a small C++20 library for simulations, tests, games, data tools, and
 other programs that need a lot of random numbers. Give it the same seed and it
-produces the same results — on another compiler, another operating system,
+produces the same results on another compiler, another operating system,
 another CPU, and whether the work runs on one thread or sixty-four. You can
 write a generator's position to a file and pick it up somewhere else, jump to
 any point in a stream in constant time, and hand every worker its own stream
 without locks. It is also quick: on a machine with AVX-512 it generates numbers
 several times faster than `std::mt19937`.
 
-> vphilox is still in early development, but all four backends are now real and
-> verified on hardware: scalar, AVX2, AVX-512 and NEON. Against `std::mt19937`
-> on the raw kernel, AVX-512 measures 4.6x on Skylake-SP and 2.6x on Sapphire
-> Rapids, and AVX2 measures 2.4x on Coffee Lake. NEON is the exception at 0.89x
-> -- the one target where vphilox is still behind. Every backend produces the
+> vphilox has not been tagged yet, so the API may still change. The bit stream is
+> frozen regardless: for a given key and counter it produces the same bytes now
+> and in every later release. All four backends are implemented and verified on
+> hardware, and filling a buffer runs at 1.3x to 4.6x the throughput of
+> `std::mt19937` across the five CPUs benchmarked. The low end of that range is a
+> Raspberry Pi 5 under NEON; drawing one value at a time on that machine is
+> 0.87x, the one place where vphilox comes out behind. Every backend produces the
 > same bytes, checked against the published Random123 vectors and pinned by a
-> digest test across five CPUs. Follow the work in the [roadmap](ROADMAP.md).
+> digest test. PractRand runs clean to a terabyte and TestU01 BigCrush passes all
+> 160 statistics. Follow the work in the [roadmap](ROADMAP.md).
 
 ## What it gives you
 
@@ -87,10 +90,22 @@ random.generate(block);                     // or: random.generate_n(ptr, count)
 ```
 
 This produces exactly the same numbers, in the same order, as calling
-`random()` a million times, and leaves the generator in the same place — you
-can mix the two styles on one engine. On a machine with AVX2 it runs about
-1.7 times faster than the one-at-a-time loop. Ask for a few hundred values or
-more to get the full benefit.
+`random()` a million times, and leaves the generator in the same place, so you
+can mix the two styles on one engine. It runs 1.5 to 2.4 times faster than the
+one-at-a-time loop, and the faster the machine's kernel, the wider that gap
+gets. Ask for a few hundred values or more to get the full benefit.
+
+## Where it stands against other generators
+
+On four of the five CPUs benchmarked, xoshiro256++ costs less per byte than
+vphilox does. The exception is Skylake-SP, where the bulk path comes in at
+0.4210 cycles per byte against xoshiro's 0.4703. xoshiro is a latency-bound
+scalar chain that a wider kernel does not catch, and it offers none of what this
+library is for: a checkpoint that survives a change of standard library,
+constant-time seek, and output that does not depend on thread count. Speed here
+only has to be good enough that portability costs nothing. The full table,
+including PCG64 and unspecialised Philox, is in
+[`docs/benchmarks/README.md`](docs/benchmarks/README.md).
 
 ## Using it from several threads
 
@@ -109,21 +124,33 @@ one shared generator.
 
 For reproducible jobs, keep the worker-to-seed mapping stable between runs.
 
+Size the pool by physical cores rather than by `hardware_concurrency()`. Cost per
+byte stays flat out to sixteen cores when each worker gets its own core, but two
+workers sharing one core's hyperthread siblings each lose about a third of their
+throughput. The kernel is execution-port-bound, so the siblings are competing for
+the same ports; measurements ruling out memory bandwidth, frequency, and
+instruction supply as the cause are in
+[`docs/benchmarks/`](docs/benchmarks/README.md).
+
 ## Saving and restoring a generator
 
 A long job that checkpoints needs to write its generator down and pick it up
-later — sometimes on a different machine. That is the one thing
-`std::mt19937` cannot do: each standard library writes its 624 internal numbers
-differently, so a checkpoint written on Linux fails to load on Windows, and on
-macOS it loads silently wrong.
+later, sometimes on a different machine. That is the one thing `std::mt19937`
+cannot do: each standard library writes its 624 internal numbers differently, so
+a checkpoint written on Linux fails to load on Windows, and on macOS it loads
+silently wrong.
 
-vphilox writes a position instead — a key and how far along the stream you are:
+vphilox writes a position instead, meaning a key and how far along the stream
+you are:
 
 ```cpp
 #include <vphilox/serialize.hpp>
 
+vphilox::engine random{42};
+for (int i = 0; i < 1000; ++i) (void)random();
+
 std::ostringstream out;
-out << random;                  // "vphilox1 3735928559 0 100 0 0 0 0"
+out << random;                  // "vphilox1 42 0 250 0 0 0 0"
 
 vphilox::engine restored;
 std::istringstream in{out.str()};
@@ -143,10 +170,10 @@ same output. That makes it easy to split a large job into independent pieces or
 resume at a known position.
 
 Philox calculations are also independent of one another, so vphilox processes
-several at once with the vector instructions on modern CPUs: eight counters at
-a time under AVX2, sixteen under AVX-512, four under NEON. The plain scalar
-path is the reference that every faster path must match bit for bit, and a test
-checks that it does on every CPU the library runs on.
+several at once with the vector instructions on modern CPUs: eight counters at a
+time under AVX2, sixteen under AVX-512, and eight under NEON as two groups of
+four. The plain scalar path is the reference that every faster path must match
+bit for bit, and a test checks that it does on every CPU the library runs on.
 
 ## Add vphilox to a project
 
@@ -222,10 +249,17 @@ across compiler versions, CPU types, and future vphilox releases.
 `tests/test_reference_vectors.cpp` checks the scalar engine against the
 published Random123 values. `tests/test_kernel_parity.cpp` checks that each SIMD
 backend gives the same answer, including requests that do not fill a complete
-vector register.
+vector register. `tests/test_cross_platform_parity.cpp` folds 8191 blocks into a
+digest and compares it with a constant, which covers what the published vectors
+cannot: SIMD tails, the refill buffer, chunked bulk calls, the counter carry
+chain, and float conversion.
 
-Long statistical runs with PractRand and TestU01 are planned for Phase 4. They
-have not been completed yet.
+The stream has also been through the two standard batteries.
+[PractRand](docs/statistical-validation.md) reported no anomalies over a
+terabyte of output, and all four backends produced that terabyte byte for byte.
+TestU01 BigCrush passed all 160 statistics. A third check compares the stream
+against NVIDIA cuRAND and writes down the seeding mapping between the two
+libraries, in [`docs/curand-parity.md`](docs/curand-parity.md).
 
 ## Repository map
 
@@ -234,16 +268,25 @@ include/vphilox/          Public headers
 include/vphilox/detail/   Scalar and SIMD backends, CPU checks, dispatch
 tests/                    GoogleTest correctness tests
 benchmarks/               Google Benchmark programs
-tools/                    Raw output tool for statistical testing
+tools/                    Raw stream, TestU01 driver, cuRAND cross-check
+scripts/                  Benchmark harness and statistical battery runners
+results/                  Archived benchmark JSON and battery logs
 docs/                     Theory, research, plans, and recorded results
+paper/                    The LaTeX write-up and its figures
 ```
 
 The technical background lives in the documentation:
 
 - [How Philox and vphilox work](docs/vPhilox%20theory.md)
+- [Measured results, figures, and the rules they follow](docs/benchmarks/README.md)
+- [Statistical validation](docs/statistical-validation.md)
 - [Research and prior work](docs/Research%20on%20vPhilox.md)
 - [Development strategy](docs/Vector%20Philox%20Development%20Strategy.md)
 - [Current roadmap](ROADMAP.md)
+
+Benchmarks are run through `scripts/benchmarks/run_matrix.sh` rather than by
+hand. It pins the governor, records provenance beside the numbers, and refuses a
+run whose cycles-per-byte varies by more than 1%.
 
 ## Versioning
 
@@ -257,10 +300,18 @@ Start with [`CONTRIBUTING.md`](CONTRIBUTING.md). New behavior needs a focused
 test. New SIMD code must pass the shared parity checks and should include
 benchmark results in both cycles per byte and GB/s.
 
-## Reference
+## Citing vphilox
 
-J. K. Salmon, M. A. Moraes, R. O. Dror, and D. E. Shaw. *Parallel Random
-Numbers: As Easy as 1, 2, 3.* SC'11.
+[`CITATION.cff`](CITATION.cff) holds the machine-readable record; GitHub turns it
+into BibTeX or APA from the "Cite this repository" button on the sidebar.
+
+The generator itself is not ours. It comes from J. K. Salmon, M. A. Moraes,
+R. O. Dror, and D. E. Shaw, *Parallel Random Numbers: As Easy as 1, 2, 3*, SC'11,
+[doi:10.1145/2063384.2063405](https://doi.org/10.1145/2063384.2063405). Cite that
+paper for Philox and cite vphilox for this implementation.
+
+The write-up of the design and the measurements is in
+[`paper/`](paper/README.md).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,11 @@ study is measured — a bare-metal Tiger Lake laptop cleared the co-location gat
 that no earlier host could — and the cuRAND cross-check is done without needing
 a GPU at all. **Phase 5 is under way:** the paper in `paper/` is a complete
 draft with every Phase 4 result folded in, and the changelog covers Phases 2
-through 4. What is left needs things this repository cannot produce on its own —
-the XGBoost thread URL, an affiliation, a Zenodo DOI, an arXiv submission, a
-tag, and vcpkg/Conan packaging.
+through 4. What is left needs things this repository cannot produce on its own:
+the XGBoost thread URL, an affiliation, a tag, a Zenodo DOI, a TechRxiv
+preprint, an arXiv endorsement, and vcpkg/Conan packaging. The route through
+those services, and the reason for their order, is in
+[`docs/publishing-guide.md`](docs/publishing-guide.md).
 
 Current version
 `2026.08.0` (see [VERSIONING.md](VERSIONING.md)).
@@ -50,7 +52,7 @@ Not in the original five-phase plan, but nothing else can start without it.
 - [x] GitHub Actions CI (build + test matrix)
 - [x] `.clang-format`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CITATION.cff`
 - [x] License story settled — dual MIT/Apache-2.0 per the docs; SPDX headers on every source file
-- [ ] README badges once CI has run at least once on the remote
+- [x] README badges once CI has run at least once on the remote
 
 ---
 
@@ -637,12 +639,21 @@ and whose state can be written on one platform and read on another.
   - [x] **Portable-state analysis** — §1, §3 and §9.1. The failure mode, the counter-based
         answer, and now an external check that the answer interoperates: 16/16 cases identical
         against NVIDIA cuRAND, with the seeding mapping documented in `docs/curand-parity.md`
-- [ ] arXiv preprint (cs.PF / cs.MS)
-- [ ] Zenodo DOI for the repository
-- [ ] Tag and publish `sinhaparth5/vphilox`
-- [x] `CITATION.cff` for one-click BibTeX
+The publishing route is written down in
+[`docs/publishing-guide.md`](docs/publishing-guide.md), and the order matters:
+Zenodo archives the *software*, TechRxiv hosts the *paper*, and arXiv comes last
+because it needs an endorsement that is easier to obtain once the preprint and
+the DOI both exist. The same manuscript must not go to both Zenodo and TechRxiv,
+or one paper ends up with two competing DOIs.
+
+- [ ] Tag and publish `sinhaparth5/vphilox` — everything below depends on it
+- [ ] Zenodo DOI for the tagged release (software archive, not the manuscript)
 - [ ] Update `CITATION.cff` with the DOI once Zenodo assigns one
-- [ ] Package for vcpkg and Conan
+- [ ] TechRxiv preprint (IEEE-operated, moderated, supplies the paper's DOI)
+- [ ] arXiv preprint (cs.PF primary, cs.MS secondary) once endorsed
+- [x] `CITATION.cff` for one-click BibTeX
+- [ ] Package for vcpkg and Conan — needs the release tarball URL and hash, so
+      it cannot start before the tag
 - [x] Release notes in `CHANGELOG.md` — `[Unreleased]` now covers the whole of Phases 2
       through 4: the serialized state, all three SIMD kernels, the cuRAND cross-check, the
       per-worker counters and placement gate, the figure pipeline, the cross-platform

--- a/docs/benchmarks/raspberry-pi-2026-08-22.md
+++ b/docs/benchmarks/raspberry-pi-2026-08-22.md
@@ -36,6 +36,8 @@ Lake result, this supports treating that slowdown as external context rather
 than a project result. An AVX-512 measurement is still needed to complete
 issue #9.
 
-The source artifacts are
-[`results/pi-arm-baseline.json`](../../results/pi-arm-baseline.json) and
-[`results/pi-arm-environment.txt`](../../results/pi-arm-environment.txt).
+The source artifact is
+[`results/pi-arm-baseline.json`](../../results/pi-arm-baseline.json). This run
+predates `run_matrix.sh`, so no environment file was captured beside it; the
+environment table above is the whole provenance record. Every archived run from
+`pi-arm-matrix` onwards has a `-environment.txt` next to its JSON.

--- a/paper/README.md
+++ b/paper/README.md
@@ -85,6 +85,19 @@ contrasts of four numbers, which a plot makes harder to read rather than easier,
 and adding them to `publish_results.py` would put two more byte-reproducible
 SVG/PDF pairs under CI's `--check` for no gain in legibility.
 
+## Where it goes when it is done
+
+[`docs/publishing-guide.md`](../docs/publishing-guide.md) has the route. The
+short version: Zenodo archives the software and its data, TechRxiv hosts the
+manuscript and supplies its DOI, and arXiv comes last because submitting there
+requires an endorsement that is easier to get once the preprint and the software
+DOI already exist. Do not post the manuscript to Zenodo as well, or one paper
+ends up with two competing DOIs.
+
+arXiv wants the LaTeX source rather than a locally built PDF, which is what
+`./stage-figures.sh` is for: run it, then submit `vphilox.tex` plus
+`figures/*.pdf` as a flat directory.
+
 ## What is still open
 
 The `\todo` markers in the source are the list, and there are two left:
@@ -97,7 +110,14 @@ The `\todo` markers in the source are the list, and there are two left:
 2. **Zenodo DOI**, in the Availability section and in `CITATION.cff`.
 
 Plus one that is not a `\todo` marker because it is a red placeholder in the
-author block: the **affiliation line** on the title page.
+author block: the **affiliation line** on the title page. The publishing guide
+suggests `Independent Researcher, City, Country` for an unaffiliated submission.
+An ORCID belongs there too, and Zenodo asks for one separately.
+
+One thing on the list is not a repository task at all. The guide asks for at
+least one knowledgeable reader to go over the claims, citations, methodology,
+figures and language before the preprint is posted. Nothing in CI substitutes for
+that.
 
 Three earlier entries are closed. The PractRand release is pinned to
 `PractRand-pre0.95` with the SourceForge project URL; the cuRAND reference is


### PR DESCRIPTION
## What this fixes

The README was written mid-Phase-3 and had drifted. Four factual errors, all
user-visible:

| Claim | Reality |
|---|---|
| "Long statistical runs with PractRand and TestU01 are planned for Phase 4. They have not been completed yet." | Both are done and archived: PractRand clean to 1 TB, byte-identical across backends, TestU01 BigCrush 160/160 |
| "NEON is the exception at 0.89x, the one target where vphilox is still behind" | The NEON kernel is 1.33x `std::mt19937` on the Pi 5. Only the *buffered* path is behind, at 0.87x |
| "AVX2 measures 2.4x on Coffee Lake" | That run is Tiger Lake (`docs/benchmarks/avx2-2026-08-23.md`), and `machines.csv` marks it *harness validation: unpinned governor*, so it should not be quoted at all |
| `out << random;  // "vphilox1 3735928559 0 100 0 0 0 0"` | No engine produces that. The third field counts blocks, not words, so 1000 draws reads 250. The key also did not match the seed in the example above it |

Every number now comes from the five published `*-matrix.csv` files. The
serialization snippet is self-contained and its output was verified by running
it. So was the code in "A small example" (compiles clean under `-Wall -Wextra`).

## What this adds

Things a reader arriving from the paper would look for and not find:

- **How it compares.** xoshiro256++ costs less per byte on four of the five
  machines; Skylake-SP is the one where vphilox leads. `CLAUDE.md` requires
  reporting this, and the README was the one public document omitting it.
- **Pool sizing.** Size by physical cores, not `hardware_concurrency()`. This is
  the most actionable measured result in the project.
- **How to cite**, pointing at `CITATION.cff` and separating the Salmon et al.
  citation for Philox from the citation for this implementation.
- Links to `docs/benchmarks/README.md`, `docs/statistical-validation.md` and
  `docs/curand-parity.md`, plus `paper/`, `scripts/` and `results/` in the
  repository map.

## Publishing route

`docs/publishing-guide.md` existed but nothing linked to it, and ROADMAP's Phase
5 list contradicted it: it had arXiv and Zenodo, no TechRxiv, and no ordering.
ROADMAP and `paper/README.md` now follow the guide (tag, then Zenodo for the
software, then TechRxiv for the manuscript, then arXiv once endorsed) and note
why the same manuscript must not go to both Zenodo and TechRxiv.

`CITATION.cff`'s TODO now names the three edits the tag needs, including that
`date-released: 2026-08-21` is the day the file was written rather than a
release date, plus the missing ORCID.

## Also

- Fixed the one broken relative link in the repo, in
  `raspberry-pi-2026-08-22.md`. `results/pi-arm-environment.txt` never existed:
  that run predates `run_matrix.sh`.
- `CONTRIBUTING.md` said to benchmark on a quiet pinned machine without
  mentioning `run_matrix.sh`, which does the pinning, the rebuild, the
  provenance and the CV gate. Its SIMD section still read as though no kernel
  had shipped.
- Ticked the Phase 0 README-badges box, which the badges have satisfied for a
  while.

## Compatibility

Documentation only. No header, build, or test file is touched, and the bit
stream is untouched. 113/113 on the `default` preset;
`publish_results.py --check` clean.