### PR TITLE
Make the release check reachable, and give it something to check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
     branches: [master, main]
+    # Without this, the release-readiness job below is unreachable: its only
+    # guard is a tag ref, and a workflow with no tag trigger never sees one.
+    tags: ['v*']
   pull_request:
   workflow_dispatch:
 
@@ -99,12 +102,16 @@ jobs:
           cmake --build b
           ./b/app
 
+  # Runs only on a tag push. Everything here is a mistake that is expensive to
+  # undo once the tag is public and Zenodo has minted a DOI against it, and
+  # cheap to catch in the ninety seconds before that happens.
   version-check:
-    name: VERSION matches tag
+    name: release readiness
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
+
       - name: Compare tag against the VERSION file
         run: |
           file_version="$(tr -d '[:space:]' < VERSION)"
@@ -113,6 +120,44 @@ jobs:
             echo "::error::tag $GITHUB_REF_NAME does not match VERSION ($file_version)"
             exit 1
           fi
+
+      # A tag whose changes are still filed under [Unreleased] ships a changelog
+      # that describes the previous release. VERSION alone does not catch it:
+      # 2026.08.0 sat in VERSION with its own dated section for the whole of
+      # Phases 2 through 4, so a tag matching VERSION could still have pointed
+      # at a section reading "there is no speedup yet".
+      - name: Changelog has a section for this version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if ! grep -qE "^## \[${version}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${version}]' section"
+            exit 1
+          fi
+          # Body of [Unreleased], up to the next level-2 heading.
+          unreleased="$(awk '/^## \[Unreleased\]/{f=1;next} /^## /{f=0} f' CHANGELOG.md \
+                        | grep -v '^[[:space:]]*$' || true)"
+          if [ -n "$unreleased" ]; then
+            echo "::error::[Unreleased] is not empty; move it under [${version}] before tagging"
+            printf '%s\n' "$unreleased" | head -5
+            exit 1
+          fi
+
+      # The paper is part of what a release archives, and a placeholder that
+      # reaches a DOI stays there. \todo renders visibly in the PDF; the
+      # affiliation is a red \textcolor rather than a \todo, so grepping for
+      # \todo alone misses it.
+      - name: Paper has no unfilled placeholders
+        run: |
+          status=0
+          if grep -n '\\todo' paper/vphilox.tex; then
+            echo "::error file=paper/vphilox.tex::unresolved \\todo markers"
+            status=1
+          fi
+          if grep -n 'Affiliation: department' paper/vphilox.tex; then
+            echo "::error file=paper/vphilox.tex::affiliation placeholder still in the author block"
+            status=1
+          fi
+          exit "$status"
 
   format:
     name: clang-format

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -646,7 +646,11 @@ because it needs an endorsement that is easier to obtain once the preprint and
 the DOI both exist. The same manuscript must not go to both Zenodo and TechRxiv,
 or one paper ends up with two competing DOIs.
 
-- [ ] Tag and publish `sinhaparth5/vphilox` — everything below depends on it
+- [ ] Tag and publish `sinhaparth5/vphilox` — everything below depends on it.
+      The tag bumps MICRO: `2026.08.0` was never tagged but already has a dated
+      changelog section describing the Phase 0/1 scaffold, so reusing it would
+      ship release notes that say there is no speedup yet. `VERSIONING.md` has
+      the steps and CI's `release readiness` job enforces them
 - [ ] Zenodo DOI for the tagged release (software archive, not the manuscript)
 - [ ] Update `CITATION.cff` with the DOI once Zenodo assigns one
 - [ ] TechRxiv preprint (IEEE-operated, moderated, supplies the paper's DOI)
@@ -658,7 +662,8 @@ or one paper ends up with two competing DOIs.
       through 4: the serialized state, all three SIMD kernels, the cuRAND cross-check, the
       per-worker counters and placement gate, the figure pipeline, the cross-platform
       parity digest, and the four measured results worth not re-deriving. It still needs a
-      release heading rather than `[Unreleased]` when the tag goes out
+      release heading rather than `[Unreleased]` when the tag goes out, and CI's
+      `release readiness` job now fails the tag if that has not happened
 
 ---
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -48,12 +48,31 @@ not a legal octal digit).
 1. Edit `VERSION`.
 2. `cmake --build build && ctest --test-dir build` — `test_version.cpp` checks
    the plumbing.
-3. Add a `CHANGELOG.md` entry.
-4. Commit, then tag as `v<VERSION>` (e.g. `v2026.08.0`).
+3. Rename `CHANGELOG.md`'s `[Unreleased]` heading to the new version and date
+   it, then open a fresh empty `[Unreleased]` above it.
+4. Update `version` and `date-released` in `CITATION.cff`, and the version
+   badge in `README.md`.
+5. Commit, then tag as `v<VERSION>` (e.g. `v2026.08.1`).
 
 Same year and month as the last release? Bump MICRO. New month? New
 `YYYY.0M.0`. Months with no release are simply skipped — there is no
 obligation to ship monthly.
+
+Pushing the tag runs CI's `release readiness` job, which is the only job gated
+on a tag ref. It fails the tag if `VERSION` and the tag disagree, if
+`CHANGELOG.md` has no section for that version, if `[Unreleased]` still has
+content in it, or if `paper/vphilox.tex` still holds a `\todo` marker or the
+affiliation placeholder. Those are all cheap to fix beforehand and awkward
+afterwards, because a tag is what Zenodo mints a DOI against.
+
+**`2026.08.0` was never tagged.** It has a dated `CHANGELOG.md` section and it
+is what `VERSION` still says, but no `v2026.08.0` exists in the repository and
+that section describes the Phase 0/1 scaffold, down to a *Known limitations*
+entry reading "SIMD kernels fall back to scalar; there is no speedup yet". The
+first real tag therefore bumps MICRO rather than reusing that number.
+
+`docs/publishing-guide.md` picks up from the tag: Zenodo archives the release,
+TechRxiv hosts the paper, arXiv follows.
 
 ## Compatibility contract
 


### PR DESCRIPTION
## The bug

`ci.yml` has a job guarded on a tag ref:

```yaml
  version-check:
    if: startsWith(github.ref, 'refs/tags/v')
```

but the workflow's triggers are `push: branches: [master, main]`, `pull_request`
and `workflow_dispatch`. **There is no tag trigger, so the job has never run and
could not have.** The repository has zero tags today, which means the first one
would have gone out with nothing checking it. It shows up in the checks list as
`skipping` on every PR, which reads like a job that is waiting its turn rather
than one that is unreachable.

`tags: ['v*']` on the push trigger fixes it.

## What it checks now

With the job reachable it is worth more than one string comparison. A tag is
what Zenodo mints a DOI against, so these mistakes are cheap to catch in ninety
seconds and awkward to undo afterwards.

**VERSION matches the tag.** Unchanged.

**The changelog is rolled over.** The tagged version needs a `## [<version>]`
section and `[Unreleased]` must be empty. VERSION alone does not catch this, and
this repository is the proof: `2026.08.0` has sat in `VERSION` with its own
dated section through the whole of Phases 2 to 4. Tagging `v2026.08.0` today
passes the version comparison and ships release notes whose *Known limitations*
read "SIMD kernels fall back to scalar; there is no speedup yet".

**The paper has no placeholders.** No `\todo`, and no affiliation placeholder.
The affiliation is a red `\textcolor` rather than a `\todo`, so grepping for
`\todo` alone misses it. Both render visibly in the PDF that the DOI would then
point at.

## Verification

Run against copies of the tree in both directions.

Current `master`, tagged `v2026.08.0`:

```
step1 VERSION: PASS
step2a section: PASS
step2b unreleased empty: FAIL   <- [Unreleased] holds all of Phases 2-4
step3 paper: FAIL               <- 2 \todo markers + the affiliation
```

A tree with `VERSION` bumped to `2026.08.1`, the changelog rolled over and the
placeholders filled, tagged `v2026.08.1`:

```
step1 VERSION: PASS
step2a section: PASS
step2b unreleased empty: PASS
step3 paper: PASS
overall: 0
```

`ci.yml` parses as valid YAML with all six jobs and the four expected steps.

## Docs

`VERSIONING.md`'s "Cutting a release" was four steps and did not mention
`CITATION.cff`, the README badge, or the gate. It now covers all three and states
plainly that **`2026.08.0` was never tagged**, so the first real tag bumps MICRO
rather than reusing a number whose release notes describe the Phase 0/1 scaffold.
ROADMAP's tag entry says the same thing where someone working the Phase 5 list
will see it.

## Compatibility

CI and documentation only. No library, test, or benchmark file is touched. The
new job is inert on every branch push and pull request; it runs only on `v*`
tags.