### PR TITLE
Fill the affiliation and ORCID

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,8 @@ authors:
   - family-names: Sinha
     given-names: Parth
     email: sinhaparth555@gmail.com
+    orcid: "https://orcid.org/0009-0002-3120-9301"
+    affiliation: "Independent Researcher, Oxford, United Kingdom"
 repository-code: "https://github.com/sinhaparth5/vphilox"
 license:
   - Apache-2.0
@@ -36,8 +38,7 @@ keywords:
 #   2. Add `doi:` with the Zenodo DOI reserved for the tagged release.
 #   3. Add a `preferred-citation:` block for the TechRxiv preprint, and swap it
 #      for the arXiv version if and when that supersedes it.
-# `orcid:` under `authors` is worth filling in at the same time; Zenodo and
-# arXiv both ask for it. See docs/publishing-guide.md.
+# See docs/publishing-guide.md.
 references:
   - type: conference-paper
     title: "Parallel Random Numbers: As Easy as 1, 2, 3"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,8 @@ that no earlier host could — and the cuRAND cross-check is done without needin
 a GPU at all. **Phase 5 is under way:** the paper in `paper/` is a complete
 draft with every Phase 4 result folded in, and the changelog covers Phases 2
 through 4. What is left needs things this repository cannot produce on its own:
-the XGBoost thread URL, an affiliation, a tag, a Zenodo DOI, a TechRxiv
-preprint, an arXiv endorsement, and vcpkg/Conan packaging. The route through
+a tag, a Zenodo DOI, a TechRxiv preprint, an arXiv endorsement, and vcpkg/Conan
+packaging. The XGBoost citation and the affiliation are both filled. The route through
 those services, and the reason for their order, is in
 [`docs/publishing-guide.md`](docs/publishing-guide.md).
 
@@ -588,8 +588,7 @@ and whose state can be written on one platform and read on another.
       §1 quotes the review comment on dmlc/xgboost#12485 verbatim, discloses in a
       footnote that this author submitted the proposal it declined, and cites
       dmlc/xgboost#12459 as an unrelated user's report of the same failure in the field.
-      One gap is a red placeholder rather than a `\todo`: the affiliation line in the
-      author block.
+      The affiliation and ORCID are filled in the author block and `CITATION.cff`.
 
       All four Phase 4 results are now folded in. §8.3 reports the instruction-supply
       measurement (#53), §8.4 the OpenMP runtime contrast (#52), §9.1 the cuRAND

--- a/paper/README.md
+++ b/paper/README.md
@@ -104,10 +104,9 @@ The `\todo` markers in the source are the list, and there is one left: the
 **Zenodo DOI**, in the Availability section and in `CITATION.cff`. It cannot be
 filled before the release exists, so it is not a writing task.
 
-Plus one that is not a `\todo` marker because it is a red placeholder in the
-author block: the **affiliation line** on the title page. The publishing guide
-suggests `Independent Researcher, City, Country` for an unaffiliated submission.
-An ORCID belongs there too, and Zenodo asks for one separately.
+The affiliation and ORCID are filled: *Independent researcher, Oxford, United
+Kingdom*, ORCID `0009-0002-3120-9301`, in both the author block and
+`CITATION.cff`. Nothing red is left on the title page.
 
 The XGBoost citation, which used to be the item blocking publication, is filled.
 Section 1 quotes the review comment on

--- a/paper/vphilox.tex
+++ b/paper/vphilox.tex
@@ -76,9 +76,10 @@
 
 \author{Parth~Sinha%
   \IEEEcompsocitemizethanks{%
-    \IEEEcompsocthanksitem P. Sinha is with
-      \textcolor{red}{[Affiliation: department, institution, city, country.]}\protect\\
-      E-mail: sinhaparth555@gmail.com
+    \IEEEcompsocthanksitem P. Sinha is an independent researcher,
+      Oxford, United Kingdom.\protect\\
+      E-mail: sinhaparth555@gmail.com\protect\\
+      ORCID: \href{https://orcid.org/0009-0002-3120-9301}{0009-0002-3120-9301}
     \IEEEcompsocthanksitem Source, measurement data and the scripts that
       regenerate every figure in this paper:
       \url{https://github.com/sinhaparth5/vphilox}}%


### PR DESCRIPTION
Independent researcher, Oxford, United Kingdom. ORCID 0009-0002-3120-9301, checksum verified against ISO 7064 MOD 11-2 before use.

Both go in the paper's author block and in CITATION.cff, where the ORCID also gives Zenodo something to link the archived release to. The title page now has nothing red on it, and the only placeholder left anywhere is the Zenodo DOI, which cannot be written before the release exists.