### PR TITLE
Record the concept DOI and route the paper to arXiv

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,9 +40,10 @@ keywords:
 # when the citation is to vphilox rather than to 2026.08.1. Bump `doi` on each
 # release; the concept DOI never changes.
 #
-# TODO(phase-5): one edit left. Add a `preferred-citation:` block for the
-# TechRxiv preprint once it has a DOI, and swap it for the arXiv version if and
-# when that supersedes it. See docs/publishing-guide.md.
+# TODO(phase-5): one edit left. Add a `preferred-citation:` block once the paper
+# is posted and has an identifier. That was going to be a TechRxiv DOI; TechRxiv
+# closed to submissions during a platform migration, so it will be the arXiv ID.
+# See docs/publishing-guide.md.
 identifiers:
   - type: doi
     value: "10.5281/zenodo.22103482"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,13 +33,20 @@ keywords:
   - high-performance computing
   - reproducibility
   - C++20
-# The `doi` above is the Zenodo record for this specific version. If the record
-# also has a concept DOI covering every version, prefer that one here so a
-# citation keeps resolving after the next release.
+# Two Zenodo DOIs, deliberately. `doi` above is this exact version, which is what
+# paper/vphilox.tex cites when it says "the release measured here", and it agrees
+# with the `version` and `date-released` in this file. The concept DOI below
+# covers every version and always resolves to the newest, so it is the one to use
+# when the citation is to vphilox rather than to 2026.08.1. Bump `doi` on each
+# release; the concept DOI never changes.
 #
 # TODO(phase-5): one edit left. Add a `preferred-citation:` block for the
 # TechRxiv preprint once it has a DOI, and swap it for the arXiv version if and
 # when that supersedes it. See docs/publishing-guide.md.
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.22103482"
+    description: "Concept DOI, resolving to the latest released version"
 references:
   - type: conference-paper
     title: "Parallel Random Numbers: As Easy as 1, 2, 3"

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -19,12 +19,22 @@ the tagged source, benchmark data, scripts, documentation, version number,
 license, repository URL, and ORCID. Once checked, publish the record to activate
 the DOI. See the [Zenodo DOI guide](https://help.zenodo.org/docs/deposit/describe-records/reserve-doi/).
 
-**Done.** The reserved DOI is
-[10.5281/zenodo.22103483](https://doi.org/10.5281/zenodo.22103483), and it is
-recorded in `CITATION.cff`, `README.md`, `CHANGELOG.md` and the paper's
-Availability section. Zenodo also mints a concept DOI covering every version of
-a record; if this one has one, `CITATION.cff` should carry that instead, so a
-citation survives the next release.
+**Done.** The record is published, holding the `v2026.08.1` source archive.
+
+```text
+10.5281/zenodo.22103483   this version, cited by the paper
+10.5281/zenodo.22103482   concept DOI, always the newest version
+```
+
+The version DOI is recorded in `CITATION.cff`, `README.md`, `CHANGELOG.md` and
+the paper's Availability section; the concept DOI is in `CITATION.cff` under
+`identifiers`. Reserving the DOI before the tag is what let the paper cite it,
+so a later release must reserve its own before rebuilding the PDF.
+
+Do not switch on Zenodo's GitHub integration for this repository. It mints a
+fresh DOI on every published GitHub Release, which would leave a second record
+competing with this one and would not match the identifier already printed in
+the paper.
 
 ## 2. Finish the Manuscript
 

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -4,7 +4,8 @@ This guide records the recommended route for making the paper and its supporting
 software public as an independent researcher. Each service has a different job:
 
 - **Zenodo** preserves the software, benchmark data, and reproducibility files.
-- **TechRxiv** hosts the research paper as a computer-science preprint.
+- **TechRxiv** hosted the paper as a computer-science preprint, and is closed
+  to new submissions during a platform migration (see §3).
 - **arXiv** provides the eventual subject-indexed preprint after endorsement.
 - A journal or conference provides peer review; none of the services above does.
 
@@ -54,25 +55,39 @@ Before publishing the preprint:
 - ~~Add the Zenodo software DOI and rebuild `paper/vphilox.pdf`.~~ Done.
 - **Open.** Ask at least one knowledgeable reader to check the claims,
   citations, methodology, figures, and language. This is the last item before
-  the manuscript goes to TechRxiv, and it is the one nothing in the repository
+  the manuscript is posted anywhere, and it is the one nothing in the repository
   can substitute for.
 
-## 3. Post the Paper on TechRxiv
+## 3. Post the Paper
 
-Upload the completed PDF to [TechRxiv](https://www.techrxiv.org/). TechRxiv is
-an IEEE-operated, moderated preprint repository for computer science,
-engineering, and related technology. It is a better home for the manuscript
-than a general-purpose Zenodo publication record and supplies a citable DOI.
-See the [IEEE TechRxiv overview](https://innovate.ieee.org/techrxiv/).
+**TechRxiv is closed to new submissions** as of 2026-08-26, during a migration to
+a new platform. Existing content stays up and its DOIs keep resolving, but there
+is no announced reopening date, so it cannot be the route. This section used to
+send the manuscript there first, on the reasoning that an IEEE-operated moderated
+repository beats a general-purpose one and hands back a citable DOI on the same
+day.
 
-Do not also upload the same manuscript to Zenodo as a separate publication.
-That would create competing DOI records for one paper. Keep the records distinct:
+Go to arXiv instead (§4). It was always the better home for a cs.PF paper; the
+only reason it came second is that a first submission needs an endorsement, and
+a TechRxiv DOI was the thing to show an endorser. **The published Zenodo record
+does that job better** — an archived, reproducible artifact is a stronger claim
+than a preprint identifier.
+
+If endorsement takes long enough to be a problem, post the manuscript as a
+Zenodo record of its own, resource type Publication → Preprint, kept separate
+from the software record. The rule this guide used to give — never put the
+manuscript on Zenodo — existed to stop a second DOI competing with the TechRxiv
+one. With no TechRxiv DOI, nothing competes. What still holds is that the two
+records stay distinct:
 
 ```text
-Zenodo DOI   -> software and reproducibility archive
-TechRxiv DOI -> paper
-arXiv ID     -> later arXiv version
+10.5281/zenodo.22103482  concept DOI  -> the software, all versions
+10.5281/zenodo.22103483  version DOI  -> the software at 2026.08.1
+arXiv ID                              -> the paper
 ```
+
+One manuscript, one identifier for it. If TechRxiv reopens after the paper is
+already posted somewhere, leave it alone rather than minting a second.
 
 ## 4. Find an arXiv Endorser
 
@@ -84,7 +99,7 @@ Search recent related papers in cs.PF, cs.MS, or cs.DC. On an abstract page,
 select **Which authors of this paper are endorsers?** Contact one relevant
 researcher at a time and provide:
 
-- The TechRxiv paper and DOI.
+- The paper itself, as a PDF or a link to a posted preprint.
 - The public GitHub repository and Zenodo software DOI.
 - Your ORCID or professional profile.
 - The arXiv endorsement link or code.


### PR DESCRIPTION
Two changes, both consequences of publishing the Zenodo record.

## The concept DOI

The published record carries two identifiers, and only one was written down.

```text
10.5281/zenodo.22103483   this version — cited by the paper's Availability section
10.5281/zenodo.22103482   concept DOI — always resolves to the newest release
```

`CITATION.cff` keeps the version DOI in `doi`, where it agrees with the `version` and `date-released` beside it, and gains the concept DOI under `identifiers`. Putting the concept DOI in `doi` instead would have contradicted both of those fields and the paper, which cites a specific measured release.

The guide also gains a warning learned this week: **do not switch on Zenodo's GitHub integration for this repository.** It mints a fresh DOI on every published GitHub Release, which would leave a second record competing with this one and would not match the identifier already printed in `paper/vphilox.pdf`. The DOI has to be reserved *before* the tag, because the PDF has to contain it.

## TechRxiv is closed

TechRxiv stopped accepting submissions on 2026-08-26 for a platform migration, with no announced reopening. Published content and its DOIs are unaffected, but it cannot be the route for this paper, and §3 sent the reader straight at it.

The paper now goes to arXiv (cs.PF primary, cs.MS secondary). That was always the better home; the only reason it came second is that a first arXiv submission needs an endorsement and a TechRxiv DOI was the thing to show an endorser. The published Zenodo record does that job better — an archived, reproducible artifact is a stronger claim than a preprint identifier.

The rule against putting the manuscript on Zenodo drops from a prohibition to a fallback. Its premise was a competing TechRxiv DOI that no longer exists. One manuscript still gets one identifier, and if TechRxiv reopens after the paper is posted, the guide now says to leave it alone rather than mint a second.

**Compatibility impact: none.** Metadata and documentation only.

## Verification

- `zenodo.org/api/records/22103483` returns `doi`, `conceptdoi`, `version: 2026.08.1`, and the `vphilox-2026.08.1.tar.gz` archive
- `CITATION.cff` parses, with the expected `doi`, `identifiers` and `version`
- no line in the guide still routes the reader to a TechRxiv submission